### PR TITLE
POAP display modifications

### DIFF
--- a/components/EventAttendanceVerification.tsx
+++ b/components/EventAttendanceVerification.tsx
@@ -5,12 +5,12 @@ import { ETH_GLOBAL_BRUSSELS_EVENT_NAMES, EVENT_VENUE } from '../utils/eventCons
 
 interface POAPEvent {
   event: {
-    id: string;
+    id: number;
     name: string;
     image_url: string;
     start_date: string;
   };
-  token_id: string;
+  tokenId: string;
 }
 
 interface EventInfo {
@@ -57,9 +57,8 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
         )
       );
 
-      // Add a minimum delay for the drumroll effect (3 seconds)
-      await new Promise(resolve => setTimeout(resolve, 3000));
-
+      // Add a minimum delay for the drumroll effect (15 seconds)
+      await new Promise(resolve => setTimeout(resolve, 15000));
       if (ethGlobalBrusselsPoap) {
         console.log('Found ETHGlobal Brussels POAP:', ethGlobalBrusselsPoap);
         setPoapDetails(ethGlobalBrusselsPoap);
@@ -76,7 +75,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
           date: ethGlobalBrusselsPoap.event.start_date,
           venue: EVENT_VENUE,
           verifiedName: verifiedName,
-          tokenId: ethGlobalBrusselsPoap.token_id
+          tokenId: ethGlobalBrusselsPoap.tokenId
         };
 
         onVerified(true, eventInfo);
@@ -201,7 +200,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                       <p>🎭 Role: {poapDetails.event.name.replace('ETHGlobal Brussels ', '')}</p>
                       <p>📅 Date: {new Date(poapDetails.event.start_date).toLocaleDateString()}</p>
                       <p>📍 Venue: {EVENT_VENUE}</p>
-                      <p>🎫 Token ID: {poapDetails.token_id}</p>
+                      <p>🎫 Token ID: {poapDetails.tokenId}</p>
                     </div>
                   </div>
                 </div>

--- a/test/mocks/poapData.ts
+++ b/test/mocks/poapData.ts
@@ -1,11 +1,11 @@
 export interface POAPEvent {
   event: {
-    id: string;
+    id: number;
     name: string;
     image_url: string;
     start_date: string;
   };
-  token_id: string;
+  tokenId: string;
 }
 
 export interface EventInfo {
@@ -24,30 +24,30 @@ export interface ErrorResponse {
 export const mockPoapsResponse: POAPEvent[] = [
   {
     event: {
-      id: "123456",
+      id: 123456,
       name: "ETHGlobal Brussels Hacker",
       image_url: "https://assets.poap.xyz/ethglobal-brussels-2024-hacker-2024-logo.png",
       start_date: "2024-02-17"
     },
-    token_id: "7890123"
+    tokenId: "7890123"
   },
   {
     event: {
-      id: "123457",
+      id: 123457,
       name: "ETHGlobal Brussels Speaker",
       image_url: "https://assets.poap.xyz/ethglobal-brussels-2024-speaker-2024-logo.png",
       start_date: "2024-02-17"
     },
-    token_id: "7890124"
+    tokenId: "7890124"
   },
   {
     event: {
-      id: "123458",
+      id: 123458,
       name: "Some Other Event",
       image_url: "https://assets.poap.xyz/other-event-2024-logo.png",
       start_date: "2024-02-17"
     },
-    token_id: "7890125"
+    tokenId: "7890125"
   }
 ];
 

--- a/utils/fetchPoapsUtil.ts
+++ b/utils/fetchPoapsUtil.ts
@@ -5,6 +5,7 @@ interface POAPEvent {
     id: number;
     name: string;
     image_url: string;
+    event_url: string;
     start_date: string;
     end_date?: string;
     description?: string;
@@ -67,8 +68,9 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
               id: Number(poap.event.id),
               name: poap.event.name || "Unknown Event",
               image_url: poap.event.image_url || "",
+              event_url: poap.event.event_url || "",
               start_date: poap.event.start_date || '',
-              end_date: poap.event.name === "ETHGlobal Brussels 2024 Hacker" ? "14-Jul-2024" : poap.event.end_date,
+              end_date: (poap.event.event_url || "").toLowerCase().includes('brussels') ? "14-Jul-2024" : poap.event.end_date,
               description: poap.event.description
             },
             tokenId: poap.tokenId,

--- a/utils/fetchPoapsUtil.ts
+++ b/utils/fetchPoapsUtil.ts
@@ -6,8 +6,8 @@ interface POAPEvent {
     name: string;
     image_url: string;
     start_date: string;
-    end_date: string;
-    description: string;
+    end_date?: string;
+    description?: string;
   };
   tokenId: string;
   metadata?: {
@@ -64,10 +64,12 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
           }
           return {
             event: {
-              id: String(poap.event.id),
+              id: Number(poap.event.id),
               name: poap.event.name || "Unknown Event",
               image_url: poap.event.image_url || "",
               start_date: poap.event.start_date || '',
+              end_date: poap.event.end_date,
+              description: poap.event.description
             },
             tokenId: poap.tokenId,
             metadata,

--- a/utils/fetchPoapsUtil.ts
+++ b/utils/fetchPoapsUtil.ts
@@ -2,15 +2,17 @@ import axios from 'axios';
 
 interface POAPEvent {
   event: {
-    id: string;
+    id: number;
     name: string;
     image_url: string;
     start_date: string;
+    end_date: string;
+    description: string;
   };
-  token_id: string;
+  tokenId: string;
   metadata?: {
-    image?: string;
-  } | null;
+    image: string;
+  };
 }
 
 export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
@@ -38,7 +40,7 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
       return [];
     }
 
-    if (!Array.isArray(response.data) || !response.data.every(poap => poap.event && poap.token_id)) {
+    if (!Array.isArray(response.data) || !response.data.every(poap => poap.event && poap.tokenId)) {
       throw new Error(`POAP API error: Invalid response format`);
     }
 
@@ -54,7 +56,7 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
               const metadataResponse = await axios.get(ipfsUrl, { timeout: 5000 });
               metadata = metadataResponse.data;
             } catch (error) {
-              console.warn(`Error fetching IPFS metadata for POAP ${poap.token_id}:`, error);
+              console.warn(`Error fetching IPFS metadata for POAP ${poap.tokenId}:`, error);
               metadata = { image: poap.event.image_url };
             }
           } else {
@@ -62,12 +64,12 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
           }
           return {
             event: {
-              id: poap.event.id,
+              id: String(poap.event.id),
               name: poap.event.name || "Unknown Event",
               image_url: poap.event.image_url || "",
               start_date: poap.event.start_date || '',
             },
-            token_id: poap.token_id,
+            tokenId: poap.tokenId,
             metadata,
           };
         })

--- a/utils/fetchPoapsUtil.ts
+++ b/utils/fetchPoapsUtil.ts
@@ -68,7 +68,7 @@ export const fetchPoaps = async (userAddress: string): Promise<POAPEvent[]> => {
               name: poap.event.name || "Unknown Event",
               image_url: poap.event.image_url || "",
               start_date: poap.event.start_date || '',
-              end_date: poap.event.end_date,
+              end_date: poap.event.name === "ETHGlobal Brussels 2024 Hacker" ? "14-Jul-2024" : poap.event.end_date,
               description: poap.event.description
             },
             tokenId: poap.tokenId,


### PR DESCRIPTION
1. Fixed POAP Display Error:
- Updated POAPEvent interface to match API response structure
- Added event_url field for proper type safety
- Fixed property name from token_id to tokenId

2. Delay Implementation:
- Increased POAP verification delay from 3 seconds to 15 seconds
- Verified delay works correctly in the verification process

3. ETHGlobal Brussels End Date:
- Implemented fixed end_date "14-Jul-2024" for all Brussels POAPs
- Used event_url to identify Brussels POAPs (covers all variants: Hacker, Sponsor, Speaker, Mentor, Staff, Volunteer)
- Made end_date and description fields optional to match API response