### PR TITLE
fix: update event names to include 2024 for POAPs

### DIFF
--- a/utils/eventConstants.ts
+++ b/utils/eventConstants.ts
@@ -1,10 +1,10 @@
 export const ETH_GLOBAL_BRUSSELS_EVENT_NAMES = [
-  'ETHGlobal Brussels Hacker',
-  'ETHGlobal Brussels Sponsor',
-  'ETHGlobal Brussels Speaker',
-  'ETHGlobal Brussels Mentor',
-  'ETHGlobal Brussels Staff',
-  'ETHGlobal Brussels Volunteer'
+  'ETHGlobal Brussels 2024 Hacker',
+  'ETHGlobal Brussels 2024 Sponsor',
+  'ETHGlobal Brussels 2024 Speaker',
+  'ETHGlobal Brussels 2024 Mentor',
+  'ETHGlobal Brussels 2024 Staff',
+  'ETHGlobal Brussels 2024 Volunteer'
 ] as const;
 
 export const EVENT_VENUE = 'The EGG Brussels, Rue Bara 175, 1070 Brussels, Belgium';


### PR DESCRIPTION
Update the event names in utils/eventConstants.ts to include "2024", which will fix the POAP verification issue by matching the actual POAP data format.
Before: 'ETHGlobal Brussels Hacker'
After: 'ETHGlobal Brussels 2024 Hacker'
This change has been made for all role types (Hacker, Sponsor, Speaker, Mentor, Staff, Volunteer).