### PR TITLE
feat: add external link SVG icons to footer links

### DIFF
--- a/components/ExternalLinkIcon.tsx
+++ b/components/ExternalLinkIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface ExternalLinkIconProps {
+  className?: string;
+}
+
+export const ExternalLinkIcon: React.FC<ExternalLinkIconProps> = ({ className = "" }) => {
+  return (
+    <svg
+      width="13.5"
+      height="13.5"
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={`inline-block ml-1 ${className}`}
+    >
+      <path
+        fill="currentColor"
+        d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"
+      />
+    </svg>
+  );
+};

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -119,6 +119,7 @@ export const Footer = (): JSX.Element => {
               >
                 devin
               </Link>
+              <span className="text-base-content mx-4">—</span>
             </div>
             <div className="flex items-center gap-4">
               <Link

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,6 +7,7 @@ import { hardhat } from "viem/chains";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Faucet } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
+import { ExternalLinkIcon } from "./ExternalLinkIcon";
 
 const FooterContainer = tw.div`
   min-h-0 
@@ -124,17 +125,19 @@ export const Footer = (): JSX.Element => {
                 href="https://ethglobal.com/showcase/missionenrollment-i4fkr"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-accent-content hover:text-accent text-sm"
+                className="text-accent-content hover:text-accent text-sm flex items-center"
               >
                 ETHGlobal Showcase
+                <ExternalLinkIcon />
               </Link>
               <Link
                 href="https://github.com/daqhris/MissionEnrollment"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-accent-content hover:text-accent text-sm"
+                className="text-accent-content hover:text-accent text-sm flex items-center"
               >
                 GitHub
+                <ExternalLinkIcon />
               </Link>
             </div>
           </div>


### PR DESCRIPTION
1. Created a new reusable ExternalLinkIcon component
2. Added the SVG icon next to both "ETHGlobal Showcase" and "GitHub" links
3. Maintained existing styling while adding proper flex layout for icon alignment