### PR TITLE
Add Recent Attestations View and Routing

### DIFF
--- a/app/attestation/[id]/layout.tsx
+++ b/app/attestation/[id]/layout.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { ApolloProvider } from '@apollo/client';
+import { apolloClient } from '../../../services/apollo/apolloClient';
+import { ErrorBoundary } from 'react-error-boundary';
+
+function ErrorFallback({ error }: { error: Error }) {
+  return (
+    <div className="text-red-500 p-4">
+      <h2>Something went wrong:</h2>
+      <pre>{error.message}</pre>
+    </div>
+  );
+}
+
+export default function AttestationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <ApolloProvider client={apolloClient}>
+        {children}
+      </ApolloProvider>
+    </ErrorBoundary>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import "@rainbow-me/rainbowkit/styles.css";
 import "@coinbase/onchainkit/styles.css";
+import { ApolloProvider } from "@apollo/client";
 import StyledComponentsRegistry from "~~/app/registry";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import { Footer } from "~~/components/Footer";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { apolloClient } from "~~/services/apollo/apolloClient";
 
 export const metadata = getMetadata({
   title: "Mission Enrollment",
@@ -20,8 +22,10 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
         <ThemeProvider>
           <ScaffoldEthAppWithProviders>
             <StyledComponentsRegistry>
-              {children}
-              <Footer />
+              <ApolloProvider client={apolloClient}>
+                {children}
+                <Footer />
+              </ApolloProvider>
             </StyledComponentsRegistry>
           </ScaffoldEthAppWithProviders>
         </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,14 +19,14 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
     <html suppressHydrationWarning>
       <body>
         <ThemeProvider>
-          <ScaffoldEthAppWithProviders>
-            <StyledComponentsRegistry>
-              <ClientApolloProvider>
+          <ClientApolloProvider>
+            <ScaffoldEthAppWithProviders>
+              <StyledComponentsRegistry>
                 {children}
                 <Footer />
-              </ClientApolloProvider>
-            </StyledComponentsRegistry>
-          </ScaffoldEthAppWithProviders>
+              </StyledComponentsRegistry>
+            </ScaffoldEthAppWithProviders>
+          </ClientApolloProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,14 +19,14 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
     <html suppressHydrationWarning>
       <body>
         <ThemeProvider>
-          <ClientApolloProvider>
-            <ScaffoldEthAppWithProviders>
-              <StyledComponentsRegistry>
+          <ScaffoldEthAppWithProviders>
+            <StyledComponentsRegistry>
+              <ClientApolloProvider>
                 {children}
                 <Footer />
-              </StyledComponentsRegistry>
-            </ScaffoldEthAppWithProviders>
-          </ClientApolloProvider>
+              </ClientApolloProvider>
+            </StyledComponentsRegistry>
+          </ScaffoldEthAppWithProviders>
         </ThemeProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import "@rainbow-me/rainbowkit/styles.css";
 import "@coinbase/onchainkit/styles.css";
-import { ApolloProvider } from "@apollo/client";
 import StyledComponentsRegistry from "~~/app/registry";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import { Footer } from "~~/components/Footer";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
-import { apolloClient } from "~~/services/apollo/apolloClient";
 
 export const metadata = getMetadata({
   title: "Mission Enrollment",
@@ -22,10 +20,8 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
         <ThemeProvider>
           <ScaffoldEthAppWithProviders>
             <StyledComponentsRegistry>
-              <ApolloProvider client={apolloClient}>
-                {children}
-                <Footer />
-              </ApolloProvider>
+              {children}
+              <Footer />
             </StyledComponentsRegistry>
           </ScaffoldEthAppWithProviders>
         </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,7 @@ import { ThemeProvider } from "~~/components/ThemeProvider";
 import { Footer } from "~~/components/Footer";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
-import { ApolloProvider } from "@apollo/client";
-import { apolloClient } from "~~/services/apollo/apolloClient";
+import { ClientApolloProvider } from "~~/components/ClientApolloProvider";
 
 export const metadata = getMetadata({
   title: "Mission Enrollment",
@@ -22,10 +21,10 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
         <ThemeProvider>
           <ScaffoldEthAppWithProviders>
             <StyledComponentsRegistry>
-              <ApolloProvider client={apolloClient}>
+              <ClientApolloProvider>
                 {children}
                 <Footer />
-              </ApolloProvider>
+              </ClientApolloProvider>
             </StyledComponentsRegistry>
           </ScaffoldEthAppWithProviders>
         </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from "~~/components/ThemeProvider";
 import { Footer } from "~~/components/Footer";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { ApolloProvider } from "@apollo/client";
+import { apolloClient } from "~~/services/apollo/apolloClient";
 
 export const metadata = getMetadata({
   title: "Mission Enrollment",
@@ -20,8 +22,10 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): React.Reac
         <ThemeProvider>
           <ScaffoldEthAppWithProviders>
             <StyledComponentsRegistry>
-              {children}
-              <Footer />
+              <ApolloProvider client={apolloClient}>
+                {children}
+                <Footer />
+              </ApolloProvider>
             </StyledComponentsRegistry>
           </ScaffoldEthAppWithProviders>
         </ThemeProvider>

--- a/app/recent/layout.tsx
+++ b/app/recent/layout.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { ApolloProvider } from '@apollo/client';
+import { apolloClient } from '../../services/apollo/apolloClient';
+import { ErrorBoundary } from 'react-error-boundary';
+
+function ErrorFallback({ error }: { error: Error }) {
+  return (
+    <div className="text-red-500 p-4">
+      <h2>Something went wrong:</h2>
+      <pre>{error.message}</pre>
+    </div>
+  );
+}
+
+export default function RecentAttestationsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <ApolloProvider client={apolloClient}>
+        {children}
+      </ApolloProvider>
+    </ErrorBoundary>
+  );
+}

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -3,9 +3,9 @@
 import React from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
 import { ErrorBoundary } from 'react-error-boundary';
-import { ClientLayout } from '../../components/ClientLayout';
 
 function ErrorFallback({ error }: { error: Error }) {
+  console.error('[RecentAttestationsPage] Error:', error);
   return (
     <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
       <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
@@ -14,22 +14,19 @@ function ErrorFallback({ error }: { error: Error }) {
   );
 }
 
-function LoadingFallback() {
-  return (
-    <div className="flex justify-center items-center h-64">
-      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
-    </div>
-  );
-}
-
 export default function RecentAttestationsPage() {
+  console.log('[RecentAttestationsPage] Rendering page');
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
-        <ClientLayout>
-          <RecentAttestationsView title="Recent Attestations" pageSize={20} />
-        </ClientLayout>
+      <ErrorBoundary
+        FallbackComponent={ErrorFallback}
+        onError={(error) => {
+          console.error('[RecentAttestationsPage] ErrorBoundary caught:', error);
+        }}
+      >
+        <RecentAttestationsView title="Recent Attestations" pageSize={20} />
       </ErrorBoundary>
     </div>
   );

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -2,16 +2,12 @@
 
 import React from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
-import { ApolloProvider } from '@apollo/client';
-import { apolloClient } from '../../services/apollo/apolloClient';
 
 export default function RecentAttestationsPage() {
   return (
-    <ApolloProvider client={apolloClient}>
-      <div className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
-        <RecentAttestationsView title="Recent Attestations" pageSize={20} />
-      </div>
-    </ApolloProvider>
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
+      <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+    </div>
   );
 }

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
 import { ErrorBoundary } from 'react-error-boundary';
+import { ClientLayout } from '../../components/ClientLayout';
 
 function ErrorFallback({ error }: { error: Error }) {
   console.error('[RecentAttestationsPage] Error:', error);
@@ -18,16 +19,18 @@ export default function RecentAttestationsPage() {
   console.log('[RecentAttestationsPage] Rendering page');
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
-      <ErrorBoundary
-        FallbackComponent={ErrorFallback}
-        onError={(error) => {
-          console.error('[RecentAttestationsPage] ErrorBoundary caught:', error);
-        }}
-      >
-        <RecentAttestationsView title="Recent Attestations" pageSize={20} />
-      </ErrorBoundary>
-    </div>
+    <ClientLayout>
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
+        <ErrorBoundary
+          FallbackComponent={ErrorFallback}
+          onError={(error) => {
+            console.error('[RecentAttestationsPage] ErrorBoundary caught:', error);
+          }}
+        >
+          <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+        </ErrorBoundary>
+      </div>
+    </ClientLayout>
   );
 }

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -3,6 +3,7 @@
 import React, { Suspense } from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
 import { ErrorBoundary } from 'react-error-boundary';
+import { ClientLayout } from '../../components/ClientLayout';
 
 function ErrorFallback({ error }: { error: Error }) {
   return (
@@ -27,7 +28,9 @@ export default function RecentAttestationsPage() {
       <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <Suspense fallback={<LoadingFallback />}>
-          <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+          <ClientLayout>
+            <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+          </ClientLayout>
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense } from 'react';
+import React from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ClientLayout } from '../../components/ClientLayout';
@@ -27,11 +27,9 @@ export default function RecentAttestationsPage() {
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
-        <Suspense fallback={<LoadingFallback />}>
-          <ClientLayout>
-            <RecentAttestationsView title="Recent Attestations" pageSize={20} />
-          </ClientLayout>
-        </Suspense>
+        <ClientLayout>
+          <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+        </ClientLayout>
       </ErrorBoundary>
     </div>
   );

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -1,13 +1,35 @@
 'use client';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { RecentAttestationsView } from '../../components/RecentAttestationsView';
+import { ErrorBoundary } from 'react-error-boundary';
+
+function ErrorFallback({ error }: { error: Error }) {
+  return (
+    <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
+      <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
+      <pre className="text-sm overflow-auto">{error.message}</pre>
+    </div>
+  );
+}
+
+function LoadingFallback() {
+  return (
+    <div className="flex justify-center items-center h-64">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+    </div>
+  );
+}
 
 export default function RecentAttestationsPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-8">Recent Attestations</h1>
-      <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Suspense fallback={<LoadingFallback />}>
+          <RecentAttestationsView title="Recent Attestations" pageSize={20} />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/components/ClientApolloProvider.tsx
+++ b/components/ClientApolloProvider.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { ApolloProvider } from "@apollo/client";
+import { apolloClient } from "~~/services/apollo/apolloClient";
+import { ReactNode } from "react";
+
+interface ClientApolloProviderProps {
+  children: ReactNode;
+}
+
+export function ClientApolloProvider({ children }: ClientApolloProviderProps) {
+  return (
+    <ApolloProvider client={apolloClient}>
+      {children}
+    </ApolloProvider>
+  );
+}

--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+import { ApolloProvider } from '@apollo/client';
+import { apolloClient } from '~/services/apollo/apolloClient';
+
+interface ClientLayoutProps {
+  children: React.ReactNode;
+}
+
+export function ClientLayout({ children }: ClientLayoutProps) {
+  return (
+    <ApolloProvider client={apolloClient}>
+      {children}
+    </ApolloProvider>
+  );
+}

--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -11,12 +11,30 @@ interface ClientLayoutProps {
 
 export function ClientLayout({ children }: ClientLayoutProps) {
   const [mounted, setMounted] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    setMounted(true);
+    console.log('[ClientLayout] Component mounting...');
+    try {
+      setMounted(true);
+      console.log('[ClientLayout] Component mounted successfully');
+    } catch (err) {
+      console.error('[ClientLayout] Error during mounting:', err);
+      setError(err as Error);
+    }
   }, []);
 
+  if (error) {
+    return (
+      <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
+        <h2 className="text-xl font-bold mb-2">Error Initializing Application</h2>
+        <pre className="text-sm overflow-auto">{error.message}</pre>
+      </div>
+    );
+  }
+
   if (!mounted) {
+    console.log('[ClientLayout] Rendering loading state...');
     return (
       <div className="flex justify-center items-center h-64">
         <Spinner />
@@ -24,6 +42,7 @@ export function ClientLayout({ children }: ClientLayoutProps) {
     );
   }
 
+  console.log('[ClientLayout] Rendering with Apollo Provider...');
   return (
     <ApolloProvider client={apolloClient}>
       {children}

--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -1,14 +1,29 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ApolloProvider } from '@apollo/client';
 import { apolloClient } from '~/services/apollo/apolloClient';
+import { Spinner } from './assets/Spinner';
 
 interface ClientLayoutProps {
   children: React.ReactNode;
 }
 
 export function ClientLayout({ children }: ClientLayoutProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Spinner />
+      </div>
+    );
+  }
+
   return (
     <ApolloProvider client={apolloClient}>
       {children}

--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { ApolloProvider } from '@apollo/client';
-import { apolloClient } from '../services/apollo/apolloClient';
 import { Spinner } from './assets/Spinner';
 
 interface ClientLayoutProps {
@@ -42,10 +40,6 @@ export function ClientLayout({ children }: ClientLayoutProps) {
     );
   }
 
-  console.log('[ClientLayout] Rendering with Apollo Provider...');
-  return (
-    <ApolloProvider client={apolloClient}>
-      {children}
-    </ApolloProvider>
-  );
+  console.log('[ClientLayout] Rendering children...');
+  return <>{children}</>;
 }

--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { ApolloProvider } from '@apollo/client';
-import { apolloClient } from '~/services/apollo/apolloClient';
+import { apolloClient } from '../services/apollo/apolloClient';
 import { Spinner } from './assets/Spinner';
 
 interface ClientLayoutProps {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -38,11 +38,11 @@ const LeftSection = tw.div`
   pointer-events-auto
 `;
 
-const ExplorerLink = tw(Link)`
-  btn 
-  btn-primary 
-  btn-sm 
-  font-normal 
+const StyledAnchor = tw.a`
+  btn
+  btn-primary
+  btn-sm
+  font-normal
   gap-1
 `;
 
@@ -92,10 +92,12 @@ export const Footer = (): JSX.Element => {
             {isLocalNetwork && (
               <>
                 <Faucet />
-                <ExplorerLink href="/blockexplorer" passHref>
-                  <MagnifyingGlassIcon className="h-4 w-4" />
-                  <span>Block Explorer</span>
-                </ExplorerLink>
+                <Link href="/blockexplorer" passHref>
+                  <StyledAnchor>
+                    <MagnifyingGlassIcon className="h-4 w-4" />
+                    <span>Block Explorer</span>
+                  </StyledAnchor>
+                </Link>
               </>
             )}
           </LeftSection>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -43,106 +43,87 @@ type HeaderMenuLink = {
   icon?: React.ReactNode;
 };
 
-const NavBar = tw.div`
-  sticky
-  lg:static
-  top-0
-  navbar
-  bg-gradient-to-r
-  from-blue-900
-  to-blue-800
-  min-h-0
-  flex-shrink-0
-  justify-between
-  z-20
-  shadow-md
-  px-0
-  sm:px-2
-`;
+const NavBar = ({ children }: { children: React.ReactNode }) => (
+  <div className="sticky lg:static top-0 navbar bg-gradient-to-r from-blue-900 to-blue-800 min-h-0 flex-shrink-0 justify-between z-20 shadow-md px-0 sm:px-2">
+    {children}
+  </div>
+);
 
-const NavbarStart = tw.div`
-  navbar-start
-  w-auto
-  lg:w-1/2
-`;
+const NavbarStart = ({ children }: { children: React.ReactNode }) => (
+  <div className="navbar-start w-auto lg:w-1/2">
+    {children}
+  </div>
+);
 
-const DropdownContainer = tw.div`
-  lg:hidden
-  dropdown
-`;
+const DropdownContainer = React.forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+  (props, ref) => (
+    <div ref={ref} className="lg:hidden dropdown">
+      {props.children}
+    </div>
+  )
+);
 
-const BurgerMenuButton = tw.label<{ $isOpen: boolean }>`
-  ml-1
-  btn
-  text-white
-  ${(p: { $isOpen: boolean }): string => (p.$isOpen ? "hover:bg-blue-600" : "hover:bg-blue-700")}
-`;
+const BurgerMenuButton = ({ isOpen, onClick, children }: { isOpen: boolean, onClick: () => void, children: React.ReactNode }) => (
+  <label
+    tabIndex={0}
+    className={`ml-1 btn text-white ${isOpen ? "hover:bg-blue-600" : "hover:bg-blue-700"}`}
+    onClick={onClick}
+  >
+    {children}
+  </label>
+);
 
-const DropdownMenu = tw.ul`
-  menu
-  menu-compact
-  dropdown-content
-  mt-3
-  p-2
-  shadow-lg
-  bg-blue-900
-  text-white
-  rounded-lg
-  w-52
-`;
+const DropdownMenu = ({ children, onClick }: { children: React.ReactNode, onClick: () => void }) => (
+  <ul
+    tabIndex={0}
+    className="menu menu-compact dropdown-content mt-3 p-2 shadow-lg bg-blue-900 text-white rounded-lg w-52"
+    onClick={onClick}
+  >
+    {children}
+  </ul>
+);
 
-const LogoContainer = tw.div`
-  flex
-  relative
-  w-24
-  h-12
-  overflow-hidden
-`;
+const LogoContainer = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex relative w-24 h-12 overflow-hidden">
+    {children}
+  </div>
+);
 
-const LogoText = tw.div`
-  flex
-  flex-col
-`;
+const LogoText = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex flex-col">
+    {children}
+  </div>
+);
 
-const LogoTitle = tw.span`
-  font-bold
-  leading-tight
-`;
+const LogoTitle = ({ children }: { children: React.ReactNode }) => (
+  <span className="font-bold leading-tight">
+    {children}
+  </span>
+);
 
-const DesktopMenu = tw.ul`
-  hidden
-  lg:flex
-  lg:flex-nowrap
-  menu
-  menu-horizontal
-  px-1
-  gap-2
-`;
+const DesktopMenu = ({ children }: { children: React.ReactNode }) => (
+  <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">
+    {children}
+  </ul>
+);
 
-const NavbarCenter = tw.div`
-  navbar-center
-  flex
-  items-center
-  justify-center
-`;
+const NavbarCenter = ({ children }: { children: React.ReactNode }) => (
+  <div className="navbar-center flex items-center justify-center">
+    {children}
+  </div>
+);
 
-const NavbarEnd = tw.div`
-  navbar-end
-  flex-grow
-  mr-4
-`;
+const NavbarEnd = ({ children }: { children: React.ReactNode }) => (
+  <div className="navbar-end flex-grow mr-4">
+    {children}
+  </div>
+);
 
-const ChainIdentifier = tw.div`
-  text-sm
-  font-bold
-  uppercase
-  text-white
-  bg-blue-500
-  hover:bg-blue-600
-  px-4
-  py-2
-  rounded-lg
-`;
+const ChainIdentifier = ({ children }: { children: React.ReactNode }) => (
+  <div className="text-sm font-bold uppercase text-white bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded-lg">
+    {children}
+  </div>
+);
 
 export const menuLinks: HeaderMenuLink[] = [
   {
@@ -204,8 +185,7 @@ export const Header = (): JSX.Element => {
       <NavbarStart>
         <DropdownContainer ref={burgerMenuRef}>
           <BurgerMenuButton
-            tabIndex={0}
-            $isOpen={isDrawerOpen}
+            isOpen={isDrawerOpen}
             onClick={(): void => {
               setIsDrawerOpen((prevIsOpenState: boolean): boolean => !prevIsOpenState);
             }}
@@ -214,7 +194,6 @@ export const Header = (): JSX.Element => {
           </BurgerMenuButton>
           {isDrawerOpen && (
             <DropdownMenu
-              tabIndex={0}
               onClick={(): void => {
                 setIsDrawerOpen(false);
               }}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -48,7 +48,7 @@ const BurgerMenuButton = tw.label<{ $isOpen: boolean }>`
   ml-1
   btn
   text-white
-  ${(p): string => (p.$isOpen ? "hover:bg-blue-600" : "hover:bg-blue-700")}
+  ${(p: { $isOpen: boolean }): string => (p.$isOpen ? "hover:bg-blue-600" : "hover:bg-blue-700")}
 `;
 
 const DropdownMenu = tw.ul`

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -107,7 +107,7 @@ const DesktopMenu = ({ children }: { children: React.ReactNode }) => (
   </ul>
 );
 
-const NavbarCenter = ({ children }: { children: React.ReactNode }) => (
+const NavbarCenter = ({ children }: { children?: React.ReactNode }) => (
   <div className="navbar-center flex items-center justify-center">
     {children}
   </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useCallback, useRef, useState, ComponentType } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
+import Link, { LinkProps } from "next/link";
 import { usePathname } from "next/navigation";
 import tw from "tailwind-styled-components";
 import { Bars3Icon } from "@heroicons/react/24/outline";
@@ -10,7 +10,25 @@ import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaff
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 import { useChainId } from 'wagmi';
 
-const StyledLink: ComponentType<any> = Link;
+interface StyledLinkProps extends LinkProps {
+  className?: string;
+  children?: React.ReactNode;
+  $isActive?: boolean;  // Add support for styled-components props
+}
+
+const StyledLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
+  ({ className, children, $isActive, ...props }, ref) => (
+    <Link
+      {...props}
+      ref={ref}
+      className={className}
+    >
+      {children}
+    </Link>
+  )
+);
+
+StyledLink.displayName = 'StyledLink';
 
 type HeaderMenuLink = {
   label: string;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,15 +10,36 @@ import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaff
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 import { useChainId } from 'wagmi';
 
-interface StyledLinkProps extends LinkProps {
-  className?: string;
-  children?: React.ReactNode;
-  $isActive?: boolean;
+interface NavLinkProps {
+  href: string;
+  children: React.ReactNode;
+  isActive?: boolean;
+  passHref?: boolean;
 }
 
-const StyledLink = tw(Link)`
-  ${({ $isActive }: { $isActive?: boolean }) => $isActive ? "bg-blue-600 shadow-md" : ""}
+const StyledNavContainer = tw.div`
+  ${({ isActive }: { isActive?: boolean }) => isActive ? "bg-blue-600 shadow-md" : ""}
 `;
+
+const NavLink: React.FC<NavLinkProps> = ({ href, children, isActive, passHref }) => (
+  <StyledNavContainer isActive={isActive}>
+    <Link href={href} passHref={passHref} className={`
+      hover:bg-blue-500
+      hover:shadow-md
+      focus:!bg-blue-600
+      active:!text-white
+      py-1.5
+      px-3
+      text-sm
+      rounded-full
+      gap-2
+      grid
+      grid-flow-col
+    `}>
+      {children}
+    </Link>
+  </StyledNavContainer>
+);
 
 type HeaderMenuLink = {
   label: string;
@@ -74,16 +95,6 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(StyledLink)`
-  hidden
-  lg:flex
-  items-center
-  gap-2
-  ml-4
-  mr-6
-  shrink-0
-`;
-
 const LogoContainer = tw.div`
   flex
   relative
@@ -137,21 +148,6 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(Link)`
-  hover:bg-blue-500
-  hover:shadow-md
-  focus:!bg-blue-600
-  active:!text-white
-  py-1.5
-  px-3
-  text-sm
-  rounded-full
-  gap-2
-  grid
-  grid-flow-col
-  ${({ $isActive }: { $isActive: boolean }) => $isActive ? "bg-blue-600 shadow-md" : ""}
-`;
-
 export const menuLinks: HeaderMenuLink[] = [
   {
     label: "Home",
@@ -176,10 +172,10 @@ export const HeaderMenuLinks = (): JSX.Element => {
         const isActive = pathname === href;
         return (
           <li key={href}>
-            <MenuLink href={href} passHref $isActive={isActive}>
+            <NavLink href={href} isActive={isActive} passHref>
               {icon}
               <span>{label}</span>
-            </MenuLink>
+            </NavLink>
           </li>
         );
       })}
@@ -231,7 +227,7 @@ export const Header = (): JSX.Element => {
             </DropdownMenu>
           )}
         </DropdownContainer>
-        <LogoLink href="/" passHref>
+        <Link href="/" className="hidden lg:flex items-center gap-2 ml-4 mr-6 shrink-0">
           <LogoContainer>
             <Image alt="Mission Enrollment logo" className="cursor-pointer object-contain" fill src="/logo.png" />
           </LogoContainer>
@@ -239,7 +235,7 @@ export const Header = (): JSX.Element => {
             <LogoTitle>Mission Enrollment</LogoTitle>
             {/*<span className="text-xs">Ethereum dev stack</span>*/}
           </LogoText>
-        </LogoLink>
+        </Link>
         <DesktopMenu>
           <HeaderMenuLinks />
         </DesktopMenu>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,19 +16,9 @@ interface StyledLinkProps extends LinkProps {
   $isActive?: boolean;
 }
 
-const BaseLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
-  ({ className, children, $isActive, ...props }, ref) => (
-    <Link
-      {...props}
-      ref={ref}
-      className={className}
-    >
-      {children}
-    </Link>
-  )
-);
-
-BaseLink.displayName = 'BaseLink';
+const StyledLink = tw(Link)<StyledLinkProps>`
+  ${(p: { $isActive?: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
+`;
 
 type HeaderMenuLink = {
   label: string;
@@ -84,7 +74,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(BaseLink)`
+const LogoLink = tw(StyledLink)`
   hidden
   lg:flex
   items-center
@@ -147,8 +137,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(BaseLink)<{ $isActive: boolean }>`
-  ${(p: { $isActive: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
+const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
   hover:bg-blue-500
   hover:shadow-md
   focus:!bg-blue-600

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,19 +16,9 @@ interface StyledLinkProps extends LinkProps {
   $isActive?: boolean;
 }
 
-const BaseLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
-  ({ className, children, $isActive, ...props }, ref) => (
-    <Link
-      {...props}
-      ref={ref}
-      className={`${className} ${$isActive ? "bg-blue-600 shadow-md" : ""}`}
-    >
-      {children}
-    </Link>
-  )
-);
-
-BaseLink.displayName = 'BaseLink';
+const StyledLink = tw(Link)<StyledLinkProps>`
+  ${(p: { $isActive?: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
+`;
 
 type HeaderMenuLink = {
   label: string;
@@ -84,7 +74,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(BaseLink)`
+const LogoLink = tw(StyledLink)`
   hidden
   lg:flex
   items-center
@@ -147,7 +137,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(BaseLink)`
+const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
   hover:bg-blue-500
   hover:shadow-md
   focus:!bg-blue-600

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState, ComponentType } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -9,6 +9,8 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 import { useChainId } from 'wagmi';
+
+const StyledLink: ComponentType<any> = Link;
 
 type HeaderMenuLink = {
   label: string;
@@ -64,7 +66,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(Link as any)`
+const LogoLink = tw(StyledLink)`
   hidden
   lg:flex
   items-center
@@ -127,7 +129,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(Link as any)<{ $isActive: boolean }>`
+const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
   ${(p: { $isActive: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
   hover:bg-blue-500
   hover:shadow-md

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,10 +13,10 @@ import { useChainId } from 'wagmi';
 interface StyledLinkProps extends LinkProps {
   className?: string;
   children?: React.ReactNode;
-  $isActive?: boolean;  // Add support for styled-components props
+  $isActive?: boolean;
 }
 
-const StyledLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
+const BaseLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
   ({ className, children, $isActive, ...props }, ref) => (
     <Link
       {...props}
@@ -28,7 +28,7 @@ const StyledLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
   )
 );
 
-StyledLink.displayName = 'StyledLink';
+BaseLink.displayName = 'BaseLink';
 
 type HeaderMenuLink = {
   label: string;
@@ -84,7 +84,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(StyledLink)`
+const LogoLink = tw(BaseLink)`
   hidden
   lg:flex
   items-center
@@ -147,7 +147,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
+const MenuLink = tw(BaseLink)<{ $isActive: boolean }>`
   ${(p: { $isActive: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
   hover:bg-blue-500
   hover:shadow-md

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,8 +16,8 @@ interface StyledLinkProps extends LinkProps {
   $isActive?: boolean;
 }
 
-const StyledLink = tw(Link)<StyledLinkProps>`
-  ${(p: { $isActive?: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
+const StyledLink = tw(Link)`
+  ${({ $isActive }: { $isActive?: boolean }) => $isActive ? "bg-blue-600 shadow-md" : ""}
 `;
 
 type HeaderMenuLink = {
@@ -137,7 +137,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
+const MenuLink = tw(Link)`
   hover:bg-blue-500
   hover:shadow-md
   focus:!bg-blue-600
@@ -149,6 +149,7 @@ const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
   gap-2
   grid
   grid-flow-col
+  ${({ $isActive }: { $isActive: boolean }) => $isActive ? "bg-blue-600 shadow-md" : ""}
 `;
 
 export const menuLinks: HeaderMenuLink[] = [

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,9 +16,19 @@ interface StyledLinkProps extends LinkProps {
   $isActive?: boolean;
 }
 
-const StyledLink = tw(Link)<StyledLinkProps>`
-  ${(p: { $isActive?: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
-`;
+const BaseLink = React.forwardRef<HTMLAnchorElement, StyledLinkProps>(
+  ({ className, children, $isActive, ...props }, ref) => (
+    <Link
+      {...props}
+      ref={ref}
+      className={`${className} ${$isActive ? "bg-blue-600 shadow-md" : ""}`}
+    >
+      {children}
+    </Link>
+  )
+);
+
+BaseLink.displayName = 'BaseLink';
 
 type HeaderMenuLink = {
   label: string;
@@ -74,7 +84,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(StyledLink)`
+const LogoLink = tw(BaseLink)`
   hidden
   lg:flex
   items-center
@@ -137,7 +147,7 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(StyledLink)<{ $isActive: boolean }>`
+const MenuLink = tw(BaseLink)`
   hover:bg-blue-500
   hover:shadow-md
   focus:!bg-blue-600

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -64,7 +64,7 @@ const DropdownMenu = tw.ul`
   w-52
 `;
 
-const LogoLink = tw(Link)`
+const LogoLink = tw(Link as any)`
   hidden
   lg:flex
   items-center
@@ -127,8 +127,8 @@ const ChainIdentifier = tw.div`
   rounded-lg
 `;
 
-const MenuLink = tw(Link)<{ $isActive: boolean }>`
-  ${(p): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
+const MenuLink = tw(Link as any)<{ $isActive: boolean }>`
+  ${(p: { $isActive: boolean }): string => (p.$isActive ? "bg-blue-600 shadow-md" : "")}
   hover:bg-blue-500
   hover:shadow-md
   focus:!bg-blue-600

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -17,12 +17,8 @@ interface NavLinkProps {
   passHref?: boolean;
 }
 
-const StyledNavContainer = tw.div`
-  ${({ isActive }: { isActive?: boolean }) => isActive ? "bg-blue-600 shadow-md" : ""}
-`;
-
 const NavLink: React.FC<NavLinkProps> = ({ href, children, isActive, passHref }) => (
-  <StyledNavContainer isActive={isActive}>
+  <div className={`${isActive ? "bg-blue-600 shadow-md" : ""}`}>
     <Link href={href} passHref={passHref} className={`
       hover:bg-blue-500
       hover:shadow-md
@@ -38,7 +34,7 @@ const NavLink: React.FC<NavLinkProps> = ({ href, children, isActive, passHref })
     `}>
       {children}
     </Link>
-  </StyledNavContainer>
+  </div>
 );
 
 type HeaderMenuLink = {

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -117,9 +117,14 @@ const PaginationContainer = tw.div`
 ` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
 
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
+  const [isClient, setIsClient] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [dateFilter, setDateFilter] = useState("");
   const [addressFilter, setAddressFilter] = useState("");
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
     variables: {
@@ -127,7 +132,8 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
       skip: (currentPage - 1) * pageSize,
       attester: addressFilter || undefined
     },
-    fetchPolicy: 'no-cache',
+    skip: !isClient,
+    fetchPolicy: 'network-only',
     onError: (error) => {
       console.error("GraphQL query error:", error);
     }
@@ -169,6 +175,14 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
 
   const totalPages = Math.ceil(filteredAttestations.length / pageSize);
   const paginatedAttestations = filteredAttestations.slice(0, pageSize);
+
+  if (!isClient) {
+    return (
+      <LoadingWrapper>
+        <Spinner />
+      </LoadingWrapper>
+    );
+  }
 
   if (error) {
     return (

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -63,18 +63,20 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
       ) : (
         <>
           <div className="grid gap-4 mb-8">
-            {attestations.map((attestation: any) => (
+            {attestations.map((attestation: Attestation) => (
               <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                <p className="font-medium">Attester: {attestation?.attester || 'Unknown'}</p>
+                <p className="font-medium">Attester: {attestation.attester}</p>
                 <p className="text-sm text-gray-600">
-                  Time: {attestation?.time ? new Date(attestation.time * 1000).toLocaleString() : 'Unknown'}
+                  Time: {new Date(attestation.time * 1000).toLocaleString()}
                 </p>
-                {attestation?.decodedDataJson && (
+                {attestation.decodedDataJson && (
                   <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
                     {(() => {
                       try {
-                        return JSON.stringify(JSON.parse(attestation.decodedDataJson), null, 2);
+                        const decodedData = JSON.parse(attestation.decodedDataJson) as AttestationData[];
+                        return JSON.stringify(decodedData, null, 2);
                       } catch (e) {
+                        console.error('[RecentAttestationsView] JSON Parse Error:', e);
                         return 'Invalid JSON data';
                       }
                     })()}

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -14,8 +14,8 @@ interface AttestationWithDecodedData {
   recipient: string;
   refUID: string;
   revocable: boolean;
-  revocationTime: string;
-  expirationTime: string;
+  revocationTime: string | null;
+  expirationTime: string | null;
   data?: string;
 }
 

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import React from 'react';
-import { useQuery } from '@apollo/client';
-import type { Attestation } from '../types/attestation';
-import { AttestationCard } from './AttestationCard';
-import { Spinner } from './assets/Spinner';
-import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
+import React, { useEffect } from 'react';
 
 interface RecentAttestationsViewProps {
   title: string;
@@ -13,60 +8,22 @@ interface RecentAttestationsViewProps {
 }
 
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
-  const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
-    variables: {
-      take: pageSize,
-      skip: 0,
-    },
-    fetchPolicy: 'network-only',
-    onError: (error) => {
-      console.error('GraphQL query error:', error);
-    },
-  });
-
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-red-500 text-center p-4">
-        Error loading attestations: {error.message}
-      </div>
-    );
-  }
+  useEffect(() => {
+    console.log('[RecentAttestationsView] Component mounted');
+    return () => {
+      console.log('[RecentAttestationsView] Component unmounted');
+    };
+  }, []);
 
   return (
     <div className="container mx-auto px-4">
       <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>
-      {data?.attestations?.length > 0 ? (
-        <div className="space-y-6">
-          {data.attestations.map((attestation: any) => (
-            <div key={attestation.id} className="bg-white rounded-lg shadow-md p-6">
-              <AttestationCard
-                attestation={{
-                  id: attestation.id,
-                  attester: attestation.attester,
-                  recipient: attestation.recipient,
-                  refUID: attestation.refUID,
-                  revocable: attestation.revocable,
-                  revocationTime: attestation.revocationTime,
-                  expirationTime: attestation.expirationTime,
-                  data: attestation.data || '',
-                }}
-              />
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="text-center text-gray-400 py-8">
-          No attestations found
-        </div>
-      )}
+      <div className="text-center py-8">
+        <p>Loading attestations...</p>
+        <p className="text-sm text-gray-500 mt-2">
+          Page Size: {pageSize}
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import type { Attestation } from '../types/attestation';
 import { AttestationCard } from './AttestationCard';

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import type { Attestation } from '../types/attestation';

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -4,10 +4,21 @@ import React, { useState } from 'react';
 import { useQuery } from '@apollo/client';
 import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
 import { Spinner } from './assets/Spinner';
+import { Attestation, AttestationData } from '../types/attestation';
+import { ErrorBoundary } from 'react-error-boundary';
 
 interface RecentAttestationsViewProps {
   title: string;
   pageSize?: number;
+}
+
+function ErrorFallback({ error }: { error: Error }) {
+  return (
+    <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
+      <h2 className="text-xl font-bold mb-2">Something went wrong</h2>
+      <pre className="text-sm overflow-auto">{error.message}</pre>
+    </div>
+  );
 }
 
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
@@ -27,86 +38,95 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
     }
   });
 
-  // Handle initial loading state
-  if (loading && !data) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <Spinner />
-      </div>
-    );
-  }
+  const content = () => {
+    // Handle initial loading state
+    if (loading && !data) {
+      return (
+        <div className="flex justify-center items-center h-64">
+          <Spinner />
+        </div>
+      );
+    }
 
-  // Handle error state
-  if (queryError || error) {
-    const errorMessage = queryError?.message || error?.message || 'An unknown error occurred';
-    return (
-      <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
-        <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
-        <pre className="text-sm overflow-auto">{errorMessage}</pre>
-      </div>
-    );
-  }
+    // Handle error state
+    if (queryError || error) {
+      const errorMessage = queryError?.message || error?.message || 'An unknown error occurred';
+      return (
+        <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
+          <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
+          <pre className="text-sm overflow-auto">{errorMessage}</pre>
+        </div>
+      );
+    }
 
-  // Safely access data with fallbacks
-  const attestations = data?.attestations || [];
-  const totalCount = data?.attestationsCount || 0;
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    // Safely access data with fallbacks
+    const attestations = data?.attestations || [];
+    const totalCount = data?.attestationsCount || 0;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+    return (
+      <>
+        {attestations.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-gray-500">No attestations found</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-4 mb-8">
+              {attestations.map((attestation: Attestation) => (
+                <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                  <p className="font-medium">Attester: {attestation.attester}</p>
+                  <p className="text-sm text-gray-600">
+                    Time: {new Date(attestation.time * 1000).toLocaleString()}
+                  </p>
+                  {attestation.decodedDataJson && (
+                    <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
+                      {(() => {
+                        try {
+                          const decodedData = JSON.parse(attestation.decodedDataJson) as AttestationData[];
+                          return JSON.stringify(decodedData, null, 2);
+                        } catch (e) {
+                          console.error('[RecentAttestationsView] JSON Parse Error:', e);
+                          return 'Invalid JSON data';
+                        }
+                      })()}
+                    </pre>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <div className="flex justify-center gap-2">
+              <button
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1 || loading}
+                className="px-4 py-2 border rounded disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span className="px-4 py-2">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages || loading}
+                className="px-4 py-2 border rounded disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </>
+        )}
+      </>
+    );
+  };
 
   return (
     <div className="container mx-auto px-4">
       <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>
-
-      {attestations.length === 0 ? (
-        <div className="text-center py-8">
-          <p className="text-gray-500">No attestations found</p>
-        </div>
-      ) : (
-        <>
-          <div className="grid gap-4 mb-8">
-            {attestations.map((attestation: Attestation) => (
-              <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                <p className="font-medium">Attester: {attestation.attester}</p>
-                <p className="text-sm text-gray-600">
-                  Time: {new Date(attestation.time * 1000).toLocaleString()}
-                </p>
-                {attestation.decodedDataJson && (
-                  <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
-                    {(() => {
-                      try {
-                        const decodedData = JSON.parse(attestation.decodedDataJson) as AttestationData[];
-                        return JSON.stringify(decodedData, null, 2);
-                      } catch (e) {
-                        console.error('[RecentAttestationsView] JSON Parse Error:', e);
-                        return 'Invalid JSON data';
-                      }
-                    })()}
-                  </pre>
-                )}
-              </div>
-            ))}
-          </div>
-
-          <div className="flex justify-center gap-2">
-            <button
-              onClick={() => setPage(p => Math.max(1, p - 1))}
-              disabled={page === 1 || loading}
-              className="px-4 py-2 border rounded disabled:opacity-50"
-            >
-              Previous
-            </button>
-            <span className="px-4 py-2">
-              Page {page} of {totalPages}
-            </span>
-            <button
-              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages || loading}
-              className="px-4 py-2 border rounded disabled:opacity-50"
-            >
-              Next
-            </button>
-          </div>
-        </>
-      )}
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        {content()}
+      </ErrorBoundary>
     </div>
   );
 }

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -12,17 +12,23 @@ interface RecentAttestationsViewProps {
 
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
   const [page, setPage] = useState(1);
+  const [error, setError] = useState<Error | null>(null);
 
-  const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
+  const { loading, error: queryError, data } = useQuery(GET_RECENT_ATTESTATIONS, {
     variables: {
       take: pageSize,
       skip: (page - 1) * pageSize,
-      attester: null // Make attester parameter optional
+      attester: null
     },
     notifyOnNetworkStatusChange: true,
+    onError: (error) => {
+      console.error('[RecentAttestationsView] GraphQL Error:', error);
+      setError(error);
+    }
   });
 
-  if (loading) {
+  // Handle initial loading state
+  if (loading && !data) {
     return (
       <div className="flex justify-center items-center h-64">
         <Spinner />
@@ -30,19 +36,21 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
     );
   }
 
-  if (error) {
-    console.error('[RecentAttestationsView] GraphQL Error:', error);
+  // Handle error state
+  if (queryError || error) {
+    const errorMessage = queryError?.message || error?.message || 'An unknown error occurred';
     return (
       <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
         <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
-        <pre className="text-sm overflow-auto">{error.message}</pre>
+        <pre className="text-sm overflow-auto">{errorMessage}</pre>
       </div>
     );
   }
 
+  // Safely access data with fallbacks
   const attestations = data?.attestations || [];
   const totalCount = data?.attestationsCount || 0;
-  const totalPages = Math.ceil(totalCount / pageSize);
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
   return (
     <div className="container mx-auto px-4">
@@ -57,11 +65,19 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
           <div className="grid gap-4 mb-8">
             {attestations.map((attestation: any) => (
               <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                <p className="font-medium">Attester: {attestation.attester}</p>
-                <p className="text-sm text-gray-600">Time: {new Date(attestation.time * 1000).toLocaleString()}</p>
-                {attestation.decodedDataJson && (
+                <p className="font-medium">Attester: {attestation?.attester || 'Unknown'}</p>
+                <p className="text-sm text-gray-600">
+                  Time: {attestation?.time ? new Date(attestation.time * 1000).toLocaleString() : 'Unknown'}
+                </p>
+                {attestation?.decodedDataJson && (
                   <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
-                    {JSON.stringify(JSON.parse(attestation.decodedDataJson), null, 2)}
+                    {(() => {
+                      try {
+                        return JSON.stringify(JSON.parse(attestation.decodedDataJson), null, 2);
+                      } catch (e) {
+                        return 'Invalid JSON data';
+                      }
+                    })()}
                   </pre>
                 )}
               </div>
@@ -71,7 +87,7 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
           <div className="flex justify-center gap-2">
             <button
               onClick={() => setPage(p => Math.max(1, p - 1))}
-              disabled={page === 1}
+              disabled={page === 1 || loading}
               className="px-4 py-2 border rounded disabled:opacity-50"
             >
               Previous
@@ -81,7 +97,7 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
             </span>
             <button
               onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages}
+              disabled={page === totalPages || loading}
               className="px-4 py-2 border rounded disabled:opacity-50"
             >
               Next

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -121,22 +121,25 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
   const [currentPage, setCurrentPage] = useState(1);
   const [dateFilter, setDateFilter] = useState("");
   const [addressFilter, setAddressFilter] = useState("");
+  const [isApolloReady, setIsApolloReady] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
+    setIsApolloReady(true);
   }, []);
 
   const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
     variables: {
-      take: pageSize * 2,
+      take: pageSize,
       skip: (currentPage - 1) * pageSize,
-      attester: addressFilter || undefined
+      attester: addressFilter || undefined,
     },
-    skip: !isClient,
+    skip: !isClient || !isApolloReady,
     fetchPolicy: 'network-only',
     onError: (error) => {
-      console.error("GraphQL query error:", error);
-    }
+      console.error('GraphQL query error:', error);
+    },
+    notifyOnNetworkStatusChange: true,
   });
 
   const parseDecodedData = (decodedDataJson: string | undefined): Record<string, string> => {

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -1,191 +1,34 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useQuery } from '@apollo/client';
 import type { Attestation } from '../types/attestation';
 import { AttestationCard } from './AttestationCard';
 import { Spinner } from './assets/Spinner';
-import tw from 'tailwind-styled-components';
 import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
-
-interface AttestationWithDecodedData {
-  decodedDataJson: string;
-  time: string;
-  id: string;
-  attester: string;
-  recipient: string;
-  refUID: string;
-  revocable: boolean;
-  revocationTime: string | null;
-  expirationTime: string | null;
-  data?: string;
-}
-
-interface DecodedData {
-  name: string;
-  type: string;
-  signature: string;
-  value: {
-    name: string;
-    type: string;
-    value: string;
-  };
-}
-
-type ExtendedAttestation = AttestationWithDecodedData;
 
 interface RecentAttestationsViewProps {
   title: string;
   pageSize?: number;
 }
 
-const AttestationList = tw.div`
-  w-full
-  max-w-3xl
-  space-y-6
-` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
-
-const AttestationItem = tw.div`
-  bg-gray-800
-  bg-opacity-95
-  rounded-2xl
-  shadow-2xl
-  p-6
-  backdrop-blur-sm
-` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
-
-const Title = tw.h1`
-  text-3xl
-  font-extrabold
-  mb-6
-  text-center
-  text-white
-  mt-4
-` as unknown as React.FC<React.HTMLAttributes<HTMLHeadingElement>>;
-
-const StatementText = tw.p`
-  text-xl
-  font-semibold
-  text-white
-  mb-4
-  mt-0
-` as unknown as React.FC<React.HTMLAttributes<HTMLParagraphElement>>;
-
-const ValidityText = tw.p`
-  text-lg
-  font-medium
-  mb-2
-  text-white
-` as unknown as React.FC<React.HTMLAttributes<HTMLParagraphElement>>;
-
-const CritiqueText = tw.p`
-  text-gray-300
-  mb-4
-` as unknown as React.FC<React.HTMLAttributes<HTMLParagraphElement>>;
-
-const TimeText = tw.p`
-  text-sm
-  text-gray-400
-` as unknown as React.FC<React.HTMLAttributes<HTMLParagraphElement>>;
-
-const LoadingWrapper = tw.div`
-  flex
-  justify-center
-  items-center
-  h-64
-` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
-
-const FilterContainer = tw.div`
-  flex
-  flex-col
-  md:flex-row
-  gap-4
-  mb-6
-  px-4
-` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
-
-const FilterInput = tw.input`
-  input
-  input-bordered
-  w-full
-  md:w-auto
-` as unknown as React.FC<React.InputHTMLAttributes<HTMLInputElement>>;
-
-const PaginationContainer = tw.div`
-  flex
-  justify-center
-  gap-2
-  mt-6
-` as unknown as React.FC<React.HTMLAttributes<HTMLDivElement>>;
-
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
-  const [isClient, setIsClient] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [dateFilter, setDateFilter] = useState("");
-  const [addressFilter, setAddressFilter] = useState("");
-  const [isApolloReady, setIsApolloReady] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-    setIsApolloReady(true);
-  }, []);
-
   const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
     variables: {
       take: pageSize,
-      skip: (currentPage - 1) * pageSize,
-      attester: addressFilter || undefined,
+      skip: 0,
     },
-    skip: !isClient || !isApolloReady,
     fetchPolicy: 'network-only',
     onError: (error) => {
       console.error('GraphQL query error:', error);
     },
-    notifyOnNetworkStatusChange: true,
   });
 
-  const parseDecodedData = (decodedDataJson: string | undefined): Record<string, string> => {
-    if (!decodedDataJson) return {};
-    try {
-      const parsedData: DecodedData[] = JSON.parse(decodedDataJson);
-      return parsedData.reduce((acc, item) => {
-        if (item?.value?.value) {
-          acc[item.name] = item.value.value;
-        }
-        return acc;
-      }, {} as Record<string, string>);
-    } catch (error) {
-      console.error("Error parsing decoded data:", error);
-      return {};
-    }
-  };
-
-  // Filter attestations by date if filter is set
-  const filteredAttestations = React.useMemo(() => {
-    if (!data?.attestations) return [];
-    return data.attestations.filter((attestation: ExtendedAttestation) => {
-      if (!attestation) return false;
-      if (dateFilter) {
-        try {
-          const attestationDate = new Date(parseInt(attestation.time) * 1000).toISOString().split('T')[0];
-          if (attestationDate !== dateFilter) return false;
-        } catch (error) {
-          console.error("Error parsing attestation date:", error);
-          return false;
-        }
-      }
-      return true;
-    });
-  }, [data?.attestations, dateFilter]);
-
-  const totalPages = Math.ceil(filteredAttestations.length / pageSize);
-  const paginatedAttestations = filteredAttestations.slice(0, pageSize);
-
-  if (!isClient) {
+  if (loading) {
     return (
-      <LoadingWrapper>
+      <div className="flex justify-center items-center h-64">
         <Spinner />
-      </LoadingWrapper>
+      </div>
     );
   }
 
@@ -199,94 +42,30 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
 
   return (
     <div className="container mx-auto px-4">
-      {loading ? (
-        <LoadingWrapper>
-          <Spinner />
-        </LoadingWrapper>
-      ) : (
-        <>
-          <Title>{title}</Title>
-
-          <FilterContainer>
-            <FilterInput
-              type="date"
-              value={dateFilter}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDateFilter(e.target.value)}
-              placeholder="Filter by date"
-            />
-            <FilterInput
-              type="text"
-              value={addressFilter}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddressFilter(e.target.value)}
-              placeholder="Filter by attester address"
-            />
-          </FilterContainer>
-
-          {paginatedAttestations.length > 0 ? (
-            <AttestationList>
-              {paginatedAttestations.map((attestation: ExtendedAttestation) => {
-                if (!attestation) return null;
-                const decodedData = parseDecodedData(attestation.decodedDataJson);
-                return (
-                  <AttestationItem key={attestation.id}>
-                    {decodedData.requestedTextToVerify && (
-                      <StatementText>{decodedData.requestedTextToVerify}</StatementText>
-                    )}
-                    {decodedData.validity && (
-                      <ValidityText>
-                        Validity: <span className="font-bold capitalize">{decodedData.validity}</span>
-                      </ValidityText>
-                    )}
-                    {decodedData.critique && (
-                      <CritiqueText>{decodedData.critique}</CritiqueText>
-                    )}
-                    <TimeText>
-                      Attested on: {new Date(parseInt(attestation.time) * 1000).toLocaleString()}
-                    </TimeText>
-                    <AttestationCard
-                      attestation={{
-                        id: attestation.id,
-                        attester: attestation.attester,
-                        recipient: attestation.recipient,
-                        refUID: attestation.refUID,
-                        revocable: attestation.revocable,
-                        revocationTime: attestation.revocationTime,
-                        expirationTime: attestation.expirationTime,
-                        data: attestation.data || '',
-                      }}
-                    />
-                  </AttestationItem>
-                );
-              })}
-            </AttestationList>
-          ) : (
-            <div className="text-center text-gray-400 py-8">
-              No attestations found
+      <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>
+      {data?.attestations?.length > 0 ? (
+        <div className="space-y-6">
+          {data.attestations.map((attestation: any) => (
+            <div key={attestation.id} className="bg-white rounded-lg shadow-md p-6">
+              <AttestationCard
+                attestation={{
+                  id: attestation.id,
+                  attester: attestation.attester,
+                  recipient: attestation.recipient,
+                  refUID: attestation.refUID,
+                  revocable: attestation.revocable,
+                  revocationTime: attestation.revocationTime,
+                  expirationTime: attestation.expirationTime,
+                  data: attestation.data || '',
+                }}
+              />
             </div>
-          )}
-
-          {totalPages > 1 && (
-            <PaginationContainer>
-              <button
-                className="btn btn-primary"
-                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                disabled={currentPage === 1}
-              >
-                Previous
-              </button>
-              <span className="flex items-center px-4">
-                Page {currentPage} of {totalPages}
-              </span>
-              <button
-                className="btn btn-primary"
-                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                disabled={currentPage === totalPages}
-              >
-                Next
-              </button>
-            </PaginationContainer>
-          )}
-        </>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center text-gray-400 py-8">
+          No attestations found
+        </div>
       )}
     </div>
   );

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
+import { Spinner } from './assets/Spinner';
 
 interface RecentAttestationsViewProps {
   title: string;
@@ -8,22 +11,84 @@ interface RecentAttestationsViewProps {
 }
 
 export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestationsViewProps): React.ReactElement {
-  useEffect(() => {
-    console.log('[RecentAttestationsView] Component mounted');
-    return () => {
-      console.log('[RecentAttestationsView] Component unmounted');
-    };
-  }, []);
+  const [page, setPage] = useState(1);
+
+  const { loading, error, data } = useQuery(GET_RECENT_ATTESTATIONS, {
+    variables: {
+      take: pageSize,
+      skip: (page - 1) * pageSize,
+      attester: null // Make attester parameter optional
+    },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    console.error('[RecentAttestationsView] GraphQL Error:', error);
+    return (
+      <div className="text-red-500 p-4 rounded-lg bg-red-50 border border-red-200">
+        <h2 className="text-xl font-bold mb-2">Error Loading Attestations</h2>
+        <pre className="text-sm overflow-auto">{error.message}</pre>
+      </div>
+    );
+  }
+
+  const attestations = data?.attestations || [];
+  const totalCount = data?.attestationsCount || 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
 
   return (
     <div className="container mx-auto px-4">
       <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>
-      <div className="text-center py-8">
-        <p>Loading attestations...</p>
-        <p className="text-sm text-gray-500 mt-2">
-          Page Size: {pageSize}
-        </p>
-      </div>
+
+      {attestations.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-gray-500">No attestations found</p>
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-4 mb-8">
+            {attestations.map((attestation: any) => (
+              <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                <p className="font-medium">Attester: {attestation.attester}</p>
+                <p className="text-sm text-gray-600">Time: {new Date(attestation.time * 1000).toLocaleString()}</p>
+                {attestation.decodedDataJson && (
+                  <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
+                    {JSON.stringify(JSON.parse(attestation.decodedDataJson), null, 2)}
+                  </pre>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="flex justify-center gap-2">
+            <button
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="px-4 py-2 border rounded disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <span className="px-4 py-2">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="px-4 py-2 border rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -1,103 +1,61 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getDefaultConfig, RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
-import type { AvatarComponent } from "@rainbow-me/rainbowkit";
+import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useTheme } from "next-themes";
 import { Toaster } from "react-hot-toast";
 import { WagmiProvider } from "wagmi";
-import { base, baseSepolia } from 'viem/chains';
-import { http } from 'wagmi';
+import { Footer } from "~~/components/Footer";
+import { Header } from "~~/components/Header";
+import { BlockieAvatar } from "~~/components/scaffold-eth";
+import { ProgressBar } from "~~/components/scaffold-eth/ProgressBar";
+import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
+import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 
-import { useInitializeNativeCurrencyPrice } from "../hooks/scaffold-eth";
-import { Footer } from "./Footer";
-import { Header } from "./Header";
-import { BlockieAvatar } from "./scaffold-eth";
-import { ProgressBar } from "./scaffold-eth/ProgressBar";
-import ErrorBoundary from "./ErrorBoundary";
-
-import "@rainbow-me/rainbowkit/styles.css";
-
-const queryClient = new QueryClient();
-
-const config = getDefaultConfig({
-  appName: 'MissionEnrollment',
-  projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || 'YOUR_PROJECT_ID',
-  chains: [baseSepolia], // Temporarily use only Base Sepolia for testing
-  transports: {
-    [baseSepolia.id]: http('https://sepolia.base.org'),
-  },
-});
-
-const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): JSX.Element => {
+const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
 
-  useEffect(() => {
-    console.log('ScaffoldEthApp mounted');
-    return () => console.log('ScaffoldEthApp unmounted');
-  }, []);
-
   return (
-    <ErrorBoundary>
+    <>
       <div className="flex flex-col min-h-screen">
         <Header />
-        <main className="relative flex flex-col flex-1">
-          {children}
-        </main>
+        <main className="relative flex flex-col flex-1">{children}</main>
         <Footer />
       </div>
       <Toaster />
-    </ErrorBoundary>
+    </>
   );
 };
 
-export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }): JSX.Element => {
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
+  const { resolvedTheme } = useTheme();
+  const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    console.log('ScaffoldEthAppWithProviders mounting...');
-    try {
-      console.log('Initializing minimal setup...');
-      setMounted(true);
-      console.log('Minimal setup complete');
-    } catch (err) {
-      console.error('Error during initialization:', err);
-      setError(err as Error);
-    }
-    return () => {
-      console.log('ScaffoldEthAppWithProviders unmounting...');
-    };
+    setMounted(true);
   }, []);
 
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen p-4">
-        <div className="text-red-500 bg-red-50 p-4 rounded-lg">
-          <h2 className="text-xl font-bold mb-2">Initialization Error</h2>
-          <pre className="text-sm">{error.message}</pre>
-        </div>
-      </div>
-    );
-  }
-
-  if (!mounted) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-      </div>
-    );
-  }
-
-  // Return minimal setup for testing
   return (
-    <ErrorBoundary>
-      <div className="flex flex-col min-h-screen">
-        <main className="relative flex flex-col flex-1">
-          {children}
-        </main>
-      </div>
-    </ErrorBoundary>
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <ProgressBar />
+        <RainbowKitProvider
+          avatar={BlockieAvatar}
+          theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
+        >
+          <ScaffoldEthApp>{children}</ScaffoldEthApp>
+        </RainbowKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
   );
 };

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -12,19 +12,22 @@ import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { ProgressBar } from "~~/components/scaffold-eth/ProgressBar";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
+import ErrorBoundary from "~~/components/ErrorBoundary";
+
+import "@rainbow-me/rainbowkit/styles.css";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
 
   return (
-    <>
+    <ErrorBoundary>
       <div className="flex flex-col min-h-screen">
         <Header />
         <main className="relative flex flex-col flex-1">{children}</main>
         <Footer />
       </div>
       <Toaster />
-    </>
+    </ErrorBoundary>
   );
 };
 
@@ -45,17 +48,27 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
     setMounted(true);
   }, []);
 
+  if (!mounted) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
   return (
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <ProgressBar />
-        <RainbowKitProvider
-          avatar={BlockieAvatar}
-          theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
-        >
-          <ScaffoldEthApp>{children}</ScaffoldEthApp>
-        </RainbowKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <ErrorBoundary>
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <ProgressBar />
+          <RainbowKitProvider
+            avatar={BlockieAvatar}
+            theme={isDarkMode ? darkTheme() : lightTheme()}
+          >
+            <ScaffoldEthApp>{children}</ScaffoldEthApp>
+          </RainbowKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </ErrorBoundary>
   );
 };

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -53,23 +53,17 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }): JSX.Elemen
 };
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }): JSX.Element => {
-  const { resolvedTheme } = useTheme();
-  const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     console.log('ScaffoldEthAppWithProviders mounting...');
     try {
-      console.log('Initializing provider setup...');
-      if (!process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID) {
-        console.warn('Warning: NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID is not set');
-      }
+      console.log('Initializing minimal setup...');
       setMounted(true);
-      console.log('Provider setup complete');
+      console.log('Minimal setup complete');
     } catch (err) {
-      console.error('Error during provider initialization:', err);
+      console.error('Error during initialization:', err);
       setError(err as Error);
     }
     return () => {
@@ -77,25 +71,18 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
     };
   }, []);
 
-  // Wait for theme to be resolved
-  useEffect(() => {
-    if (mounted && resolvedTheme) {
-      setIsInitialized(true);
-    }
-  }, [mounted, resolvedTheme]);
-
   if (error) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen p-4">
         <div className="text-red-500 bg-red-50 p-4 rounded-lg">
-          <h2 className="text-xl font-bold mb-2">Provider Initialization Error</h2>
+          <h2 className="text-xl font-bold mb-2">Initialization Error</h2>
           <pre className="text-sm">{error.message}</pre>
         </div>
       </div>
     );
   }
 
-  if (!isInitialized) {
+  if (!mounted) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
@@ -103,23 +90,14 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
     );
   }
 
+  // Return minimal setup for testing
   return (
     <ErrorBoundary>
-      <WagmiProvider config={config}>
-        <QueryClientProvider client={queryClient}>
-          <ErrorBoundary>
-            <RainbowKitProvider
-              theme={isDarkMode ? darkTheme() : lightTheme()}
-              avatar={BlockieAvatar as AvatarComponent}
-            >
-              <ErrorBoundary>
-                <ProgressBar />
-                <ScaffoldEthApp>{children}</ScaffoldEthApp>
-              </ErrorBoundary>
-            </RainbowKitProvider>
-          </ErrorBoundary>
-        </QueryClientProvider>
-      </WagmiProvider>
+      <div className="flex flex-col min-h-screen">
+        <main className="relative flex flex-col flex-1">
+          {children}
+        </main>
+      </div>
     </ErrorBoundary>
   );
 };

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -9,7 +9,6 @@ import { Toaster } from "react-hot-toast";
 import { WagmiProvider } from "wagmi";
 import { base, baseSepolia } from 'viem/chains';
 import { http } from 'wagmi';
-import { OnchainKitProvider } from "@coinbase/onchainkit";
 
 import { useInitializeNativeCurrencyPrice } from "../hooks/scaffold-eth";
 import { Footer } from "./Footer";
@@ -58,42 +57,31 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   const { resolvedTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
-  const cdpApiKey = process.env.NEXT_PUBLIC_CDP_API_KEY;
 
   useEffect(() => {
     console.log('ScaffoldEthAppWithProviders mounting...');
-
     try {
       console.log('Initializing basic provider setup...');
-      if (!cdpApiKey) {
-        console.warn('CDP API key not found in environment variables');
-      }
       setMounted(true);
       console.log('Component mounted successfully');
     } catch (error) {
       console.error('Error during initialization:', error);
     }
-
     return () => {
       console.log('ScaffoldEthAppWithProviders unmounting...');
     };
-  }, [cdpApiKey]);
+  }, []);
 
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <OnchainKitProvider
-          apiKey={cdpApiKey || ''}
-          chain={base}
+        <RainbowKitProvider
+          theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
+          avatar={BlockieAvatar as AvatarComponent}
         >
-          <RainbowKitProvider
-            theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
-            avatar={BlockieAvatar as AvatarComponent}
-          >
-            <ProgressBar />
-            <ScaffoldEthApp>{children}</ScaffoldEthApp>
-          </RainbowKitProvider>
-        </OnchainKitProvider>
+          <ProgressBar />
+          <ScaffoldEthApp>{children}</ScaffoldEthApp>
+        </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -24,9 +24,8 @@ const queryClient = new QueryClient();
 const config = getDefaultConfig({
   appName: 'MissionEnrollment',
   projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || 'YOUR_PROJECT_ID',
-  chains: [base, baseSepolia],
+  chains: [baseSepolia], // Temporarily use only Base Sepolia for testing
   transports: {
-    [base.id]: http(),
     [baseSepolia.id]: http('https://sepolia.base.org'),
   },
 });

--- a/components/ScaffoldEthAppWithProviders.tsx
+++ b/components/ScaffoldEthAppWithProviders.tsx
@@ -58,6 +58,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     console.log('ScaffoldEthAppWithProviders mounting...');
@@ -77,6 +78,13 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
     };
   }, []);
 
+  // Wait for theme to be resolved
+  useEffect(() => {
+    if (mounted && resolvedTheme) {
+      setIsInitialized(true);
+    }
+  }, [mounted, resolvedTheme]);
+
   if (error) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen p-4">
@@ -88,13 +96,21 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
     );
   }
 
+  if (!isInitialized) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
   return (
     <ErrorBoundary>
       <WagmiProvider config={config}>
         <QueryClientProvider client={queryClient}>
           <ErrorBoundary>
             <RainbowKitProvider
-              theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
+              theme={isDarkMode ? darkTheme() : lightTheme()}
               avatar={BlockieAvatar as AvatarComponent}
             >
               <ErrorBoundary>

--- a/graphql/queries.ts
+++ b/graphql/queries.ts
@@ -6,7 +6,7 @@ export const GET_RECENT_ATTESTATIONS = gql`
       take: $take
       skip: $skip
       orderBy: { time: DESC }
-      where: { attester: $attester }
+      where: { attester: { equals: $attester } }
     ) {
       id
       attester
@@ -41,7 +41,7 @@ export const GET_ATTESTATION_BY_ID = gql`
 
 export const GET_ATTESTATIONS_BY_RECIPIENT = gql`
   query GetAttestationsByRecipient($address: String!) {
-    attestations(where: { recipient: $address }) {
+    attestations(where: { recipient: { equals: $address } }) {
       id
       attester
       recipient

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false, // Temporarily disabled for debugging
   typescript: {
     ignoreBuildErrors: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^4.1.2",
     "react-hot-toast": "^2.4.1",
     "react-toastify": "^10.0.6",
     "styled-components": "^6.1.13",

--- a/server.log
+++ b/server.log
@@ -1,0 +1,12 @@
+yarn run v1.22.22
+$ next dev
+   ▲ Next.js 15.0.3
+   - Local:        http://localhost:3000
+   - Environments: .env.local, .env
+   - Experiments (use with caution):
+     · forceSwcTransforms
+
+ ✓ Starting...
+ ✓ Ready in 1555ms
+   Reload env: .env.local
+[?25h

--- a/services/apollo/apolloClient.ts
+++ b/services/apollo/apolloClient.ts
@@ -1,18 +1,31 @@
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 
 const httpLink = new HttpLink({
   uri: 'https://sepolia.easscan.org/graphql',
 });
 
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors)
+    graphQLErrors.forEach(({ message, locations, path }) =>
+      console.error(
+        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+      ),
+    );
+  if (networkError) console.error(`[Network error]: ${networkError}`);
+});
+
 export const apolloClient = new ApolloClient({
-  link: httpLink,
+  link: from([errorLink, httpLink]),
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all',
     },
     query: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all',
     },
   },
 });

--- a/services/apollo/apolloClient.ts
+++ b/services/apollo/apolloClient.ts
@@ -2,23 +2,31 @@ import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 import { RetryLink } from '@apollo/client/link/retry';
 
+console.log('[Apollo] Initializing Apollo Client configuration...');
+
 const httpLink = new HttpLink({
   uri: 'https://sepolia.easscan.org/graphql',
+  credentials: 'omit',
 });
 
 const retryLink = new RetryLink({
   delay: {
     initial: 300,
-    max: Infinity,
+    max: 3000,
     jitter: true
   },
   attempts: {
-    max: 3,
-    retryIf: (error, _operation) => !!error
+    max: 2,
+    retryIf: (error, _operation) => {
+      console.log('[Apollo] Retry attempt due to error:', error);
+      return !!error;
+    }
   }
 });
 
 const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
+  console.log('[Apollo] Error link triggered');
+
   if (graphQLErrors) {
     graphQLErrors.forEach(({ message, locations, path }) => {
       console.error(
@@ -32,19 +40,26 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
   return forward(operation);
 });
 
+console.log('[Apollo] Creating Apollo Client instance...');
+
 export const apolloClient = new ApolloClient({
   link: from([errorLink, retryLink, httpLink]),
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    addTypename: false
+  }),
   defaultOptions: {
     watchQuery: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'no-cache',
       errorPolicy: 'all',
       notifyOnNetworkStatusChange: true,
     },
     query: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'no-cache',
       errorPolicy: 'all',
       notifyOnNetworkStatusChange: true,
     },
   },
+  connectToDevTools: true
 });
+
+console.log('[Apollo] Apollo Client configuration complete');

--- a/services/apollo/apolloClient.ts
+++ b/services/apollo/apolloClient.ts
@@ -1,31 +1,50 @@
 import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
+import { RetryLink } from '@apollo/client/link/retry';
 
 const httpLink = new HttpLink({
   uri: 'https://sepolia.easscan.org/graphql',
 });
 
-const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors)
-    graphQLErrors.forEach(({ message, locations, path }) =>
+const retryLink = new RetryLink({
+  delay: {
+    initial: 300,
+    max: Infinity,
+    jitter: true
+  },
+  attempts: {
+    max: 3,
+    retryIf: (error, _operation) => !!error
+  }
+});
+
+const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
+  if (graphQLErrors) {
+    graphQLErrors.forEach(({ message, locations, path }) => {
       console.error(
         `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-      ),
-    );
-  if (networkError) console.error(`[Network error]: ${networkError}`);
+      );
+    });
+  }
+  if (networkError) {
+    console.error(`[Network error]: ${networkError}`);
+  }
+  return forward(operation);
 });
 
 export const apolloClient = new ApolloClient({
-  link: from([errorLink, httpLink]),
+  link: from([errorLink, retryLink, httpLink]),
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: {
-      fetchPolicy: 'no-cache',
+      fetchPolicy: 'network-only',
       errorPolicy: 'all',
+      notifyOnNetworkStatusChange: true,
     },
     query: {
-      fetchPolicy: 'no-cache',
+      fetchPolicy: 'network-only',
       errorPolicy: 'all',
+      notifyOnNetworkStatusChange: true,
     },
   },
 });

--- a/services/web3/wagmiConfig.ts
+++ b/services/web3/wagmiConfig.ts
@@ -1,0 +1,12 @@
+import { getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { baseSepolia } from "viem/chains";
+import { http } from "wagmi";
+
+export const wagmiConfig = getDefaultConfig({
+  appName: "MissionEnrollment",
+  projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || "YOUR_PROJECT_ID",
+  chains: [baseSepolia],
+  transports: {
+    [baseSepolia.id]: http("https://sepolia.base.org"),
+  },
+});

--- a/types/attestation.ts
+++ b/types/attestation.ts
@@ -4,7 +4,9 @@ export interface Attestation {
   recipient: string;
   refUID: string;
   revocable: boolean;
-  revocationTime: string;
-  expirationTime: string;
+  revocationTime: string | null;
+  expirationTime: string | null;
+  time: string;  // Add time field from GraphQL response
   data: string;
+  decodedDataJson?: string;  // Optional field for decoded data
 }

--- a/types/attestation.ts
+++ b/types/attestation.ts
@@ -6,7 +6,23 @@ export interface Attestation {
   revocable: boolean;
   revocationTime: string | null;
   expirationTime: string | null;
-  time: string;  // Add time field from GraphQL response
+  time: number;  // Changed from string to number to match GraphQL response
   data: string;
-  decodedDataJson?: string;  // Optional field for decoded data
+  decodedDataJson: string;  // Made required as it's always present in responses
+}
+
+export interface AttestationData {
+  name: string;
+  type: string;
+  signature: string;
+  value: {
+    name: string;
+    type: string;
+    value: string | number | boolean | { type: string; hex: string };
+  };
+}
+
+export interface AttestationQueryResponse {
+  attestations: Attestation[];
+  attestationsCount: number;
 }

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -22,6 +22,10 @@ declare module 'tailwind-styled-components' {
     button: TwElementFn;
     span: TwElementFn;
     a: TwElementFn;
+    ul: TwElementFn;
+    li: TwElementFn;
+    nav: TwElementFn;
+    footer: TwElementFn;
     [key: string]: TwElementFn;
   }
 

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -21,10 +21,12 @@ declare module 'tailwind-styled-components' {
     input: TwElementFn;
     button: TwElementFn;
     span: TwElementFn;
-    a: TwElementFn;  // Add anchor element type
+    a: TwElementFn;
     [key: string]: TwElementFn;
   }
 
-  const tw: TwElements & TwElementFn;
+  type StyledComponent = <T>(Component: ComponentType<T>) => ComponentType<T & { className?: string }>;
+
+  const tw: TwElements & StyledComponent;
   export default tw;
 }

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -21,6 +21,7 @@ declare module 'tailwind-styled-components' {
     input: TwElementFn;
     button: TwElementFn;
     span: TwElementFn;
+    a: TwElementFn;  // Add anchor element type
     [key: string]: TwElementFn;
   }
 

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -1,5 +1,5 @@
 declare module 'tailwind-styled-components' {
-  import { ComponentType, PropsWithChildren, HTMLAttributes } from 'react';
+  import { ComponentType, PropsWithChildren, HTMLAttributes, AnchorHTMLAttributes, InputHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
   export interface TwComponent extends ComponentType<any> {
     tw: string;
@@ -13,20 +13,20 @@ declare module 'tailwind-styled-components' {
   }
 
   interface TwElements {
-    div: TwElementFn;
-    p: TwElementFn;
-    h1: TwElementFn;
-    h2: TwElementFn;
-    h3: TwElementFn;
-    input: TwElementFn;
-    button: TwElementFn;
-    span: TwElementFn;
-    a: TwElementFn;
-    ul: TwElementFn;
-    li: TwElementFn;
-    nav: TwElementFn;
-    footer: TwElementFn;
-    label: TwElementFn;
+    div: TwElementFn & ComponentType<HTMLAttributes<HTMLDivElement>>;
+    p: TwElementFn & ComponentType<HTMLAttributes<HTMLParagraphElement>>;
+    h1: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
+    h2: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
+    h3: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
+    input: TwElementFn & ComponentType<InputHTMLAttributes<HTMLInputElement>>;
+    button: TwElementFn & ComponentType<ButtonHTMLAttributes<HTMLButtonElement>>;
+    span: TwElementFn & ComponentType<HTMLAttributes<HTMLSpanElement>>;
+    a: TwElementFn & ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>>;
+    ul: TwElementFn & ComponentType<HTMLAttributes<HTMLUListElement>>;
+    li: TwElementFn & ComponentType<HTMLAttributes<HTMLLIElement>>;
+    nav: TwElementFn & ComponentType<HTMLAttributes<HTMLElement>>;
+    footer: TwElementFn & ComponentType<HTMLAttributes<HTMLElement>>;
+    label: TwElementFn & ComponentType<HTMLAttributes<HTMLLabelElement>>;
     [key: string]: TwElementFn;
   }
 

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -1,5 +1,5 @@
 declare module 'tailwind-styled-components' {
-  import { ComponentType, PropsWithChildren } from 'react';
+  import { ComponentType, PropsWithChildren, HTMLAttributes } from 'react';
 
   export interface TwComponent extends ComponentType<any> {
     tw: string;
@@ -8,7 +8,7 @@ declare module 'tailwind-styled-components' {
   type TemplateFn<P = {}> = (strings: TemplateStringsArray, ...values: any[]) => ComponentType<P>;
 
   interface TwElementFn {
-    <P = {}>(strings: TemplateStringsArray, ...values: any[]): ComponentType<P>;
+    <P = {}>(strings: TemplateStringsArray, ...values: any[]): ComponentType<P & { children?: React.ReactNode }>;
     <P>(component: ComponentType<P>): ComponentType<P & { className?: string }>;
   }
 

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -7,27 +7,24 @@ declare module 'tailwind-styled-components' {
 
   type TemplateFn<P = {}> = (strings: TemplateStringsArray, ...values: any[]) => ComponentType<P>;
 
-  interface TwElementFn {
-    <P = {}>(strings: TemplateStringsArray, ...values: any[]): ComponentType<P & { children?: React.ReactNode }>;
-    <P>(component: ComponentType<P>): ComponentType<P & { className?: string }>;
-  }
+  type HTMLElementProps<T> = T & { children?: React.ReactNode; className?: string };
 
   interface TwElements {
-    div: TwElementFn & ComponentType<HTMLAttributes<HTMLDivElement>>;
-    p: TwElementFn & ComponentType<HTMLAttributes<HTMLParagraphElement>>;
-    h1: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
-    h2: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
-    h3: TwElementFn & ComponentType<HTMLAttributes<HTMLHeadingElement>>;
-    input: TwElementFn & ComponentType<InputHTMLAttributes<HTMLInputElement>>;
-    button: TwElementFn & ComponentType<ButtonHTMLAttributes<HTMLButtonElement>>;
-    span: TwElementFn & ComponentType<HTMLAttributes<HTMLSpanElement>>;
-    a: TwElementFn & ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>>;
-    ul: TwElementFn & ComponentType<HTMLAttributes<HTMLUListElement>>;
-    li: TwElementFn & ComponentType<HTMLAttributes<HTMLLIElement>>;
-    nav: TwElementFn & ComponentType<HTMLAttributes<HTMLElement>>;
-    footer: TwElementFn & ComponentType<HTMLAttributes<HTMLElement>>;
-    label: TwElementFn & ComponentType<HTMLAttributes<HTMLLabelElement>>;
-    [key: string]: TwElementFn;
+    div: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLDivElement>>>;
+    p: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLParagraphElement>>>;
+    h1: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
+    h2: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
+    h3: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
+    input: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<InputHTMLAttributes<HTMLInputElement>>>;
+    button: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<ButtonHTMLAttributes<HTMLButtonElement>>>;
+    span: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLSpanElement>>>;
+    a: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<AnchorHTMLAttributes<HTMLAnchorElement>>>;
+    ul: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLUListElement>>>;
+    li: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLIElement>>>;
+    nav: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>>>;
+    footer: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>>>;
+    label: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLabelElement>>>;
+    [key: string]: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<any>;
   }
 
   type StyledComponent = <T>(Component: ComponentType<T>) => ComponentType<T & { className?: string }>;

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -7,27 +7,27 @@ declare module 'tailwind-styled-components' {
 
   type TemplateFn<P = {}> = (strings: TemplateStringsArray, ...values: any[]) => ComponentType<P>;
 
-  type HTMLElementProps<T> = T & { children?: React.ReactNode; className?: string };
+  type HTMLElementProps<T, P = {}> = T & P & { children?: React.ReactNode; className?: string };
 
   interface TwElements {
-    div: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLDivElement>>>;
-    p: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLParagraphElement>>>;
-    h1: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
-    h2: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
-    h3: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>>>;
-    input: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<InputHTMLAttributes<HTMLInputElement>>>;
-    button: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<ButtonHTMLAttributes<HTMLButtonElement>>>;
-    span: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLSpanElement>>>;
-    a: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<AnchorHTMLAttributes<HTMLAnchorElement>>>;
-    ul: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLUListElement>>>;
-    li: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLIElement>>>;
-    nav: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>>>;
-    footer: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>>>;
-    label: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLabelElement>>>;
-    [key: string]: (strings: TemplateStringsArray, ...values: any[]) => ComponentType<any>;
+    div: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLDivElement>, P>>;
+    p: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLParagraphElement>, P>>;
+    h1: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>, P>>;
+    h2: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>, P>>;
+    h3: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLHeadingElement>, P>>;
+    input: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<InputHTMLAttributes<HTMLInputElement>, P>>;
+    button: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<ButtonHTMLAttributes<HTMLButtonElement>, P>>;
+    span: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLSpanElement>, P>>;
+    a: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<AnchorHTMLAttributes<HTMLAnchorElement>, P>>;
+    ul: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLUListElement>, P>>;
+    li: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLIElement>, P>>;
+    nav: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>, P>>;
+    footer: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLElement>, P>>;
+    label: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<HTMLElementProps<HTMLAttributes<HTMLLabelElement>, P>>;
+    [key: string]: <P = {}>(strings: TemplateStringsArray, ...values: any[]) => ComponentType<any>;
   }
 
-  type StyledComponent = <T>(Component: ComponentType<T>) => ComponentType<T & { className?: string }>;
+  type StyledComponent = <T, P = {}>(Component: ComponentType<T>) => ComponentType<T & P & { className?: string }>;
 
   const tw: TwElements & StyledComponent;
   export default tw;

--- a/types/tailwind-styled-components.d.ts
+++ b/types/tailwind-styled-components.d.ts
@@ -5,11 +5,11 @@ declare module 'tailwind-styled-components' {
     tw: string;
   }
 
-  type TemplateFn = (strings: TemplateStringsArray, ...values: any[]) => ComponentType<any>;
+  type TemplateFn<P = {}> = (strings: TemplateStringsArray, ...values: any[]) => ComponentType<P>;
 
   interface TwElementFn {
-    (strings: TemplateStringsArray, ...values: any[]): ComponentType<any>;
-    (component: ComponentType<any>): ComponentType<any>;
+    <P = {}>(strings: TemplateStringsArray, ...values: any[]): ComponentType<P>;
+    <P>(component: ComponentType<P>): ComponentType<P & { className?: string }>;
   }
 
   interface TwElements {
@@ -26,6 +26,7 @@ declare module 'tailwind-styled-components' {
     li: TwElementFn;
     nav: TwElementFn;
     footer: TwElementFn;
+    label: TwElementFn;
     [key: string]: TwElementFn;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9452,6 +9452,13 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-error-boundary@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.1.2.tgz#bc750ad962edb8b135d6ae922c046051eb58f289"
+  integrity sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-hot-toast@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"


### PR DESCRIPTION
This PR implements:

- New RecentAttestationsView component with pagination and error handling
- Dedicated routes for viewing attestations (/recent and /attestation/[id])
- GraphQL query integration for fetching recent attestations
- Error boundaries and loading states for attestation data
- Improved provider setup with proper error handling
