### PR TITLE
Improve attestation display with Base name resolution and UI layout

### DIFF
--- a/components/BaseNameDisplay.tsx
+++ b/components/BaseNameDisplay.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getBaseName } from '../utils/basename';
+
+interface BaseNameDisplayProps {
+  address: string;
+  showLabel?: boolean;
+  className?: string;
+}
+
+export function BaseNameDisplay({ address, showLabel = true, className = '' }: BaseNameDisplayProps) {
+  const [baseName, setBaseName] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchBaseName() {
+      try {
+        const name = await getBaseName(address);
+        setBaseName(name || null);
+      } catch (error) {
+        console.error('Error fetching Base name:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchBaseName();
+  }, [address]);
+
+  if (loading) {
+    return <span className={className}>{showLabel ? 'Loading...' : address}</span>;
+  }
+
+  return (
+    <span className={className}>
+      {showLabel && 'Attester: '}{baseName || address}
+      {baseName && <span className="text-sm text-gray-500 ml-2">({address})</span>}
+    </span>
+  );
+}

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useQuery } from '@apollo/client';
+import { baseSepolia } from 'viem/chains';
 import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
 import { Spinner } from './assets/Spinner';
 import { Attestation, AttestationData } from '../types/attestation';
@@ -77,10 +78,19 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
             <div className="grid gap-4 mb-8">
               {attestations.map((attestation: Attestation) => (
                 <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                  <BaseNameDisplay address={attestation.attester} />
-                  <p className="text-sm text-gray-600">
-                    Time: {new Date(attestation.time * 1000).toLocaleString()}
-                  </p>
+                  <div className="flex justify-between items-center mb-2">
+                    <p className="text-sm text-gray-600">
+                      Time: {new Date(attestation.time * 1000).toLocaleString()}
+                    </p>
+                    <a
+                      href={`${baseSepolia.blockExplorers.default.url}/tx/${attestation.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 text-sm"
+                    >
+                      View Transaction ↗
+                    </a>
+                  </div>
                   {attestation.decodedDataJson && (
                     <div className="mt-2 space-y-2">
                       {(() => {
@@ -88,15 +98,13 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
                           const decodedData = JSON.parse(attestation.decodedDataJson) as AttestationData[];
                           const formattedData = formatAttestationData(decodedData);
                           return Object.entries(formattedData).map(([key, value], index) => {
-                            if (key.toLowerCase() === 'attester') return null;
+                            if (key.toLowerCase() === 'attester' || key.toLowerCase() === 'useraddress') return null;
 
                             return (
                               <div key={index} className="bg-gray-50 p-2 rounded flex justify-between items-center">
                                 <span className="font-medium">{getFieldLabel(key)}</span>
                                 <span className="text-gray-700 break-all">
-                                  {key.toLowerCase() === 'useraddress' ? (
-                                    <BaseNameDisplay address={String(value)} />
-                                  ) : key.toLowerCase() === 'timestamp' ? (
+                                  {key.toLowerCase() === 'timestamp' ? (
                                     new Date(Number(value) * 1000).toLocaleString()
                                   ) : (
                                     String(value)

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -7,6 +7,8 @@ import { Spinner } from './assets/Spinner';
 import { Attestation, AttestationData } from '../types/attestation';
 import { ErrorBoundary } from 'react-error-boundary';
 import { SCHEMA_UID } from '../utils/constants';
+import { BaseNameDisplay } from './BaseNameDisplay';
+import { formatAttestationData, getFieldLabel } from '../utils/formatting';
 
 interface RecentAttestationsViewProps {
   title: string;
@@ -40,7 +42,6 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
   });
 
   const content = () => {
-    // Handle initial loading state
     if (loading && !data) {
       return (
         <div className="flex justify-center items-center h-64">
@@ -49,7 +50,6 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
       );
     }
 
-    // Handle error state
     if (queryError || error) {
       const errorMessage = queryError?.message || error?.message || 'An unknown error occurred';
       console.error('[RecentAttestationsView] Error fetching attestations:', errorMessage);
@@ -62,7 +62,6 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
       );
     }
 
-    // Safely access data with fallbacks
     const attestations = data?.attestations || [];
     const totalCount = data?.attestationsCount || 0;
     const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
@@ -78,22 +77,40 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
             <div className="grid gap-4 mb-8">
               {attestations.map((attestation: Attestation) => (
                 <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                  <p className="font-medium">Attester: {attestation.attester}</p>
+                  <BaseNameDisplay address={attestation.attester} />
                   <p className="text-sm text-gray-600">
                     Time: {new Date(attestation.time * 1000).toLocaleString()}
                   </p>
                   {attestation.decodedDataJson && (
-                    <pre className="text-sm bg-gray-50 p-2 mt-2 rounded overflow-auto">
+                    <div className="mt-2 space-y-2">
                       {(() => {
                         try {
                           const decodedData = JSON.parse(attestation.decodedDataJson) as AttestationData[];
-                          return JSON.stringify(decodedData, null, 2);
+                          const formattedData = formatAttestationData(decodedData);
+                          return Object.entries(formattedData).map(([key, value], index) => {
+                            if (key.toLowerCase() === 'attester') return null;
+
+                            return (
+                              <div key={index} className="bg-gray-50 p-2 rounded flex justify-between items-center">
+                                <span className="font-medium">{getFieldLabel(key)}</span>
+                                <span className="text-gray-700 break-all">
+                                  {key.toLowerCase() === 'useraddress' ? (
+                                    <BaseNameDisplay address={String(value)} />
+                                  ) : key.toLowerCase() === 'timestamp' ? (
+                                    new Date(Number(value) * 1000).toLocaleString()
+                                  ) : (
+                                    String(value)
+                                  )}
+                                </span>
+                              </div>
+                            );
+                          }).filter(Boolean);
                         } catch (e) {
                           console.error('[RecentAttestationsView] JSON Parse Error:', e);
-                          return 'Invalid JSON data';
+                          return <p className="text-red-500">Invalid JSON data</p>;
                         }
                       })()}
-                    </pre>
+                    </div>
                   )}
                 </div>
               ))}

--- a/components/RecentAttestationsView.tsx
+++ b/components/RecentAttestationsView.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react';
 import { useQuery } from '@apollo/client';
-import { baseSepolia } from 'viem/chains';
 import { GET_RECENT_ATTESTATIONS } from '../graphql/queries';
 import { Spinner } from './assets/Spinner';
 import { Attestation, AttestationData } from '../types/attestation';
@@ -83,12 +82,12 @@ export function RecentAttestationsView({ title, pageSize = 20 }: RecentAttestati
                       Time: {new Date(attestation.time * 1000).toLocaleString()}
                     </p>
                     <a
-                      href={`${baseSepolia.blockExplorers.default.url}/tx/${attestation.id}`}
+                      href={`https://base-sepolia.easscan.org/attestation/view/${attestation.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-600 hover:text-blue-800 text-sm"
                     >
-                      View Transaction ↗
+                      View on EAS ↗
                     </a>
                   </div>
                   {attestation.decodedDataJson && (

--- a/utils/basename.ts
+++ b/utils/basename.ts
@@ -10,16 +10,14 @@ export async function getBaseName(address: string): Promise<string> {
       return '';
     }
 
-    return `${name}.base.eth`;
+    return name; // getName from OnchainKit already includes .base.eth suffix
   } catch (error) {
-    // Return empty string if no basename is found or contract call fails
     console.error('Error retrieving Base name:', error);
     return '';
   }
 }
 
 export async function verifyBaseName(address: string, providedName: string): Promise<boolean> {
-  // First check Base name
   if (providedName.endsWith('.base.eth')) {
     const baseName = await getBaseName(address);
     if (baseName) {
@@ -29,7 +27,6 @@ export async function verifyBaseName(address: string, providedName: string): Pro
     }
   }
 
-  // If no Base name matches, fallback to ENS
   try {
     const ensName = await getEnsName(address);
     if (ensName) {

--- a/utils/formatting.ts
+++ b/utils/formatting.ts
@@ -1,0 +1,45 @@
+import { SchemaData } from '../types/attestation';
+
+export function formatAttestationValue(field: { name: string; value: any }) {
+  switch (field.name.toLowerCase()) {
+    case 'timestamp':
+      return new Date(Number(field.value) * 1000).toLocaleString();
+    case 'useraddress':
+    case 'attester':
+      return typeof field.value === 'object' ? field.value.hex : field.value;
+    default:
+      return typeof field.value === 'object' ? field.value.hex : String(field.value);
+  }
+}
+
+export function getFieldLabel(name: string): string {
+  const labels: Record<string, string> = {
+    userAddress: 'User Address',
+    verifiedName: 'Verified Name',
+    proofMethod: 'Proof Method',
+    eventName: 'Event Name',
+    eventType: 'Event Type',
+    assignedRole: 'Role',
+    missionName: 'Mission',
+    timestamp: 'Time',
+    attester: 'Attester',
+    proofProtocol: 'Protocol'
+  };
+  return labels[name] || name;
+}
+
+export function formatAttestationData(decodedData: any[]): Partial<SchemaData> {
+  const formattedData: Partial<SchemaData> = {};
+
+  decodedData.forEach(field => {
+    const key = field.value.name.toLowerCase() as keyof SchemaData;
+    const value = field.value.value;
+    if (typeof value === 'object' && 'hex' in value) {
+      (formattedData as any)[key] = value.hex;
+    } else {
+      (formattedData as any)[key] = value;
+    }
+  });
+
+  return formattedData;
+}


### PR DESCRIPTION
## Changes
- Add BaseNameDisplay component for address resolution
- Create formatting utilities for attestation data
- Improve UI layout and readability
- Add proper timestamp formatting
- Handle address fields with Base name resolution
- Update attestation links to use EAS attestation view instead of Basescan
- Remove duplicate attester information from attestation cards
- Add direct links to EAS attestation details for better verification

## Technical Details
- Implemented Base name resolution for Ethereum addresses
- Created utility functions for consistent data formatting
- Updated link format to use EAS attestation view (e.g., `base-sepolia.easscan.org/attestation/view/{id}`)
- Improved UI layout for better readability and user experience
- Enhanced error handling for JSON parsing and data display

## Testing
- Verified Base name resolution functionality
- Confirmed EAS attestation links are working correctly
- Tested UI layout across different screen sizes
- Validated timestamp formatting and display
