### PR TITLE
fix: increase main container padding and logo size

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,7 @@ export default function Home() {
   };
 
   return (
-    <div className="container mx-auto p-4">
+    <div className="container mx-auto p-8">
       <div className="flex items-center justify-between mb-8">
         <Logo />
       </div>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -4,15 +4,15 @@ import React from 'react';
 import Image from 'next/image';
 
 export const Logo: React.FC = () => (
-  <div className="flex items-center gap-2">
+  <div className="flex items-center gap-4">
     <Image
       src="/logo.png"
       alt="Mission Enrollment Logo"
-      width={32}
-      height={32}
+      width={64}
+      height={64}
       priority
     />
-    <span className="font-bold text-xl text-[#957777]">Mission Enrollment</span>
+    <span className="font-bold text-2xl text-[#957777]">Mission Enrollment</span>
   </div>
 );
 


### PR DESCRIPTION
Changed the padding from p-4 to p-8 in the first div tag's class attribute in app/page.tsx.
Double the logo size (text-2xl) and the gap between logo and text.