### PR TITLE
fix: increase enrollment cards padding from p-4 to p-8

### DIFF
--- a/components/EnrollmentsView.tsx
+++ b/components/EnrollmentsView.tsx
@@ -85,7 +85,7 @@ export function EnrollmentsView({ title, pageSize = 20 }: EnrollmentsViewProps):
           <>
             <div className="grid gap-4 mb-8">
               {attestations.map((attestation: Attestation) => (
-                <div key={attestation.id} className="p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-red-100/80">
+                <div key={attestation.id} className="p-8 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-red-100/80">
                   <div className="flex justify-between items-center mb-2">
                     <div className="text-gray-600 text-sm">
                       {formatDistanceToNow(new Date(attestation.time * 1000), { addSuffix: true })}


### PR DESCRIPTION
1. Location: components/EnrollmentsView.tsx
2. Change: Modified the padding from p-4 to p-8 in the first div of the attestation cards
3. Specific change: Updated the className from
   ```
   p-4 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-red-100/80
   ```
   to
   ```
   p-8 border rounded-lg shadow-sm hover:shadow-md transition-shadow bg-red-100/80
   ```