### PR TITLE
Beta status indicators across the app user interface

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import EventAttendanceVerification from '../components/EventAttendanceVerificati
 import EnrollmentAttestation from '../components/EnrollmentAttestation';
 import { SuccessAttestation } from '../components/SuccessAttestation';
 import { Logo } from '../components/Logo';
+import { BetaBanner } from '../components/BetaBanner';
 
 // Type definitions for component state
 interface EventInfo {
@@ -124,6 +125,7 @@ export default function Home() {
       <div className="flex items-center justify-between mb-8">
         <Logo />
       </div>
+      <BetaBanner />
       <div className="bg-base-100 p-6 rounded-lg shadow-lg">
         <div className="space-y-4">
           <div className="card">

--- a/components/BetaBanner.tsx
+++ b/components/BetaBanner.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+export const BetaBanner = (): JSX.Element => {
+  const [isVisible, setIsVisible] = useState(true);
+  const [hasDismissed, setHasDismissed] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem('betaBannerDismissed');
+    if (dismissed === 'true') {
+      setIsVisible(false);
+      setHasDismissed(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    setHasDismissed(true);
+    localStorage.setItem('betaBannerDismissed', 'true');
+  };
+
+  if (!isVisible) return <></>;
+
+  return (
+    <div className="w-full bg-[#957777]/20 py-2 px-4 rounded-lg mb-4 flex justify-between items-center">
+      <div className="flex items-center">
+        <div className="mr-2 text-sm font-bold border border-[#957777] px-2 py-0.5 rounded-full bg-[#957777] text-white">
+          BETA
+        </div>
+        <p className="text-sm">
+          This application is currently in beta testing. Features may change and some functionality might be limited.
+        </p>
+      </div>
+      <button 
+        onClick={handleDismiss}
+        className="text-sm hover:text-[#957777] transition-colors ml-2"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+};

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -137,6 +137,9 @@ export const Footer = (): JSX.Element => {
                 <ExternalLinkIcon />
               </Link>
             </div>
+            <div className="text-xs text-accent-content/70 flex items-center">
+              <span className="px-2 py-0.5 rounded-full border border-accent">Beta</span>
+            </div>
           </div>
         </FixedBottomBar>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -212,7 +212,9 @@ export const Header = (): JSX.Element => {
           </LogoContainer>
           <LogoText>
             <LogoTitle>mission-enrollment.base.eth</LogoTitle>
-            {/*<span className="text-xs">Ethereum dev stack</span>*/}
+            <div className="flex items-center">
+              <span className="text-xs px-2 py-0.5 bg-[#957777] text-white rounded-full ml-2 animate-pulse">Beta</span>
+            </div>
           </LogoText>
         </Link>
         <DesktopMenu>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,11 +80,22 @@ select:focus {
 }
 
 .card {
-  @apply rounded-xl shadow-lg p-6;
+  @apply rounded-xl shadow-lg p-6 relative;
   background: rgba(31, 41, 55, 0.7);
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card::after {
+  content: "BETA";
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  font-size: 0.6rem;
+  opacity: 0.3;
+  color: #957777;
+  pointer-events: none;
 }
 
 .card:hover {


### PR DESCRIPTION
# Beta Indicators Implementation

Implemented the beta indicators across the MissionEnrollment interface. 

## Changes Implemented:

1. **Header Beta Badge**: Added a pulsing "Beta" badge next to the site title in the header

2. **Footer Beta Indicator**: Added a subtle "Beta" indicator in the footer

3. **Dismissible Beta Banner**: Created a new `BetaBanner` component that displays a dismissible notification about the beta status

4. **Beta Watermark on Cards**: Added a subtle "BETA" watermark to all card components via CSS

5. **Integrated Beta Banner**: Added the beta banner to the main page

All changes maintain the existing design language and color scheme, particularly using the `#957777` color which is already part of the application's palette. The beta indicators are designed to be noticeable enough to inform users about the app's status without being distracting or interfering with the core functionality.
