### PR TITLE
Add charter page to sitemap configuration

### DIFF
--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -6,6 +6,6 @@ module.exports = {
   generateIndexSitemap: true,
   outDir: './out',
   additionalPaths: async () => {
-    return ['/about', '/enrollments', '/preview']
+    return ['/about', '/enrollments', '/preview', '/charter']
   }
 }


### PR DESCRIPTION
Updated next-sitemap.config.cjs to include /charter in the additionalPaths array.