### PR TITLE
Add network selection option and Base mainnet deployment support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import EnrollmentAttestation from '../components/EnrollmentAttestation';
 import { SuccessAttestation } from '../components/SuccessAttestation';
 import { Logo } from '../components/Logo';
 import { BetaBanner } from '../components/BetaBanner';
+import NetworkSelector from '../components/NetworkSelector';
 
 // Type definitions for component state
 interface EventInfo {
@@ -230,6 +231,7 @@ export default function Home() {
 
                   {showAttestation && eventInfo && (
                     <div className="mt-4">
+                      <NetworkSelector />
                       <EnrollmentAttestation
                         verifiedName={eventInfo.verifiedName}
                         poapVerified={eventAttendanceVerified}

--- a/app/providers/OnchainKitProvider.tsx
+++ b/app/providers/OnchainKitProvider.tsx
@@ -1,16 +1,27 @@
 import { OnchainKitProvider as BaseOnchainKitProvider } from '@coinbase/onchainkit';
-import { ReactNode } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 import { base, baseSepolia } from 'viem/chains';
 import { type Chain } from 'viem';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import { useUserNetworkPreference } from '../../hooks/useUserNetworkPreference';
 
 interface OnchainKitProviderProps {
   children: ReactNode;
 }
 
 export function OnchainKitProvider({ children }: OnchainKitProviderProps) {
-  // Get the default chain from environment or use Base Mainnet
-  const defaultChain = parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN || '8453');
+  const { preferredNetwork } = useUserNetworkPreference();
+  
+  // Get the default chain from environment or use Base Mainnet if no user preference
+  const [defaultChain, setDefaultChain] = useState<number>(
+    parseInt(process.env.NEXT_PUBLIC_DEFAULT_CHAIN || '8453')
+  );
+  
+  useEffect(() => {
+    if (preferredNetwork) {
+      setDefaultChain(preferredNetwork);
+    }
+  }, [preferredNetwork]);
 
   // Validate chain ID and select appropriate chain
   let chain: Chain;

--- a/components/EnrollmentAttestation.tsx
+++ b/components/EnrollmentAttestation.tsx
@@ -4,12 +4,13 @@ import { EAS, SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { Card, CardContent, Typography, Button, CircularProgress, Box } from '@mui/material';
 import { notification } from "../utils/scaffold-eth";
 import {
-  EAS_CONTRACT_ADDRESS_SEPOLIA,
+  EAS_CONTRACT_ADDRESS,
   SCHEMA_UID,
   MISSION_ENROLLMENT_BASE_ETH_ADDRESS,
   getRequiredNetwork,
   BASE_SEPOLIA_CHAIN_ID
 } from '../utils/constants';
+import { useUserNetworkPreference } from '../hooks/useUserNetworkPreference';
 import { SCHEMA_ENCODING } from '../types/attestation';
 import { getPOAPRole } from '../utils/poap';
 import { BrowserProvider, TransactionReceipt, Log, Interface } from 'ethers';
@@ -151,8 +152,10 @@ export default function EnrollmentAttestation({
         return;
       }
 
-      // Initialize EAS
-      const eas = new EAS(EAS_CONTRACT_ADDRESS_SEPOLIA);
+      // Initialize EAS with the correct contract address based on network
+      const { preferredNetwork } = useUserNetworkPreference();
+      const easContractAddress = EAS_CONTRACT_ADDRESS(preferredNetwork);
+      const eas = new EAS(easContractAddress);
       const provider = new BrowserProvider(window.ethereum);
       const signer = await provider.getSigner();
       eas.connect(signer);

--- a/components/NetworkCostInfo.tsx
+++ b/components/NetworkCostInfo.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Card, CardContent, Typography, Box } from '@mui/material';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+export default function NetworkCostInfo() {
+  return (
+    <Card sx={{ mb: 3, backgroundColor: 'rgba(239, 68, 68, 0.05)' }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center' }}>
+          <InformationCircleIcon className="h-5 w-5 mr-2" />
+          Network Cost Information
+        </Typography>
+        
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Base Sepolia (Testnet)</Typography>
+          <Typography variant="body2" paragraph>
+            • Gas fees only: ~0.0001 ETH (~€0.20)<br />
+            • Suitable for testing and development<br />
+            • Attestations are not stored on the main Base network
+          </Typography>
+          
+          <Typography variant="subtitle2" gutterBottom>Base Mainnet</Typography>
+          <Typography variant="body2" paragraph>
+            • Contract deployment: ~0.35 ETH (~€700)<br />
+            • Schema creation: ~0.05 ETH (~€100)<br />
+            • Per attestation cost: ~0.02 ETH (~€40)<br />
+            • Attestations are permanently stored on the Base blockchain
+          </Typography>
+          
+          <Typography variant="caption" color="text.secondary">
+            * Cost estimates are approximate and may vary based on network conditions.
+            Base ETH price estimated at €2,000 per ETH.
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/NetworkSelector.tsx
+++ b/components/NetworkSelector.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+import { useAccount, useChainId } from 'wagmi';
+import { 
+  Card, 
+  CardContent, 
+  Typography, 
+  Button, 
+  FormControlLabel,
+  Radio, 
+  RadioGroup,
+  Tooltip,
+  Box
+} from '@mui/material';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import { 
+  NETWORK_CONFIG, 
+  BASE_SEPOLIA_CHAIN_ID, 
+  BASE_MAINNET_CHAIN_ID 
+} from '../utils/constants';
+import { useUserNetworkPreference } from '../hooks/useUserNetworkPreference';
+
+export default function NetworkSelector() {
+  const { address } = useAccount();
+  const currentChainId = useChainId();
+  const { 
+    preferredNetwork, 
+    setPreferredNetwork,
+    isLoading 
+  } = useUserNetworkPreference();
+
+  const handleNetworkChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPreferredNetwork(parseInt(event.target.value));
+  };
+
+  if (!address) return null;
+
+  return (
+    <Card sx={{ mb: 3, backgroundColor: 'rgba(66, 153, 225, 0.1)' }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center' }}>
+          Network Selection
+          <Tooltip title="Choose which network to use for attestations. Base Sepolia is a testnet with minimal costs, while Base mainnet involves real transaction fees.">
+            <Box component="span" sx={{ ml: 1, cursor: 'help' }}>
+              <InformationCircleIcon className="h-5 w-5" />
+            </Box>
+          </Tooltip>
+        </Typography>
+        
+        <RadioGroup
+          value={preferredNetwork?.toString() || BASE_SEPOLIA_CHAIN_ID.toString()}
+          onChange={handleNetworkChange}
+        >
+          <FormControlLabel 
+            value={BASE_SEPOLIA_CHAIN_ID.toString()} 
+            control={<Radio />} 
+            label={
+              <Box>
+                <Typography variant="body1">{NETWORK_CONFIG[BASE_SEPOLIA_CHAIN_ID].name} (Testnet)</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Low cost option - Free attestations (gas fees only)
+                </Typography>
+              </Box>
+            }
+            disabled={isLoading}
+          />
+          <FormControlLabel 
+            value={BASE_MAINNET_CHAIN_ID.toString()} 
+            control={<Radio />} 
+            label={
+              <Box>
+                <Typography variant="body1">{NETWORK_CONFIG[BASE_MAINNET_CHAIN_ID].name} (Mainnet)</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Standard option - Estimated cost: ~0.02 ETH (~€40) per attestation
+                </Typography>
+              </Box>
+            }
+            disabled={isLoading}
+          />
+        </RadioGroup>
+        
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+          Current network: {NETWORK_CONFIG[currentChainId]?.name || 'Unknown Network'}
+          {currentChainId !== preferredNetwork && ' (Different from selected)'}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/base-mainnet-deployment-guide.md
+++ b/docs/base-mainnet-deployment-guide.md
@@ -1,0 +1,132 @@
+# Base Mainnet Deployment Guide
+
+This document provides detailed instructions for deploying the Mission Enrollment smart contracts to Base mainnet and setting up the necessary EAS schemas.
+
+## Prerequisites
+
+1. A wallet with Base ETH for gas fees (daqhris.base.eth or mission-enrollment.base.eth)
+2. Private key for the deployment wallet, set as an environment variable (`DEPLOYER_PRIVATE_KEY`)
+3. Access to a Base mainnet RPC URL, set as an environment variable (`NEXT_PUBLIC_BASE_MAINNET_RPC_URL`)
+4. OnchainKit API key, set as an environment variable (`NEXT_PUBLIC_ONCHAINKIT_API_KEY`)
+5. WalletConnect Project ID, set as an environment variable (`NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`)
+6. POAP API key, set as an environment variable (`NEXT_PUBLIC_POAP_API_KEY`)
+
+## Deployment Cost Estimates
+
+| Operation | Estimated Cost (ETH) | Estimated Cost (EUR) |
+|-----------|----------------------|----------------------|
+| Contract Deployment | ~0.35 ETH | ~€700 |
+| Schema Creation | ~0.05 ETH | ~€100 |
+| Attestation Creation (per attestation) | ~0.02 ETH | ~€40 |
+
+These estimates are based on current gas prices and ETH value. Actual costs may vary.
+
+## Deployment Steps
+
+### 1. Deploy the AttestationService Contract
+
+```bash
+# Set the network flag to deploy to Base mainnet
+npx hardhat run scripts/deploy.ts --network base-mainnet
+```
+
+This script will:
+- Deploy the AttestationService contract to Base mainnet
+- Initialize the contract with the Base mainnet EAS contract and schema registry addresses
+- Create the Mission Enrollment schema on Base mainnet
+- Output the deployed contract address and schema ID
+
+### 2. Verify the Contract on Basescan
+
+```bash
+npx hardhat verify --network base-mainnet DEPLOYED_CONTRACT_ADDRESS
+```
+
+### 3. Grant Attestation Creator Role
+
+After deployment, you need to grant the attestation creator role to the necessary addresses:
+
+```bash
+# Replace ADDRESS_TO_GRANT with the address that should be able to create attestations
+npx hardhat run scripts/grantAttestationCreatorRole.ts --network base-mainnet --address ADDRESS_TO_GRANT
+```
+
+## EAS Schema Creation Details
+
+The EAS schema for Mission Enrollment attestations has the following structure:
+
+```
+address userAddress,string verifiedName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address attester,string proofProtocol
+```
+
+This schema is created automatically during the deployment process. If you need to create it manually:
+
+1. Visit the [EAS Schema Registry](https://base.easscan.org/schema/create)
+2. Connect your wallet (daqhris.base.eth or mission-enrollment.base.eth)
+3. Enter the schema encoding string shown above
+4. Set the schema to be revocable
+5. Submit the transaction and save the schema UID
+
+## Integration with Frontend
+
+After deployment, update the following environment variables in your frontend:
+
+```
+NEXT_PUBLIC_ATTESTATION_SERVICE_ADDRESS=<deployed-contract-address>
+NEXT_PUBLIC_SCHEMA_UID=<schema-uid-from-deployment>
+```
+
+### Updating the Network Configuration
+
+The application has been updated to support both Base Sepolia (testnet) and Base mainnet. Users can select their preferred network for attestations through the NetworkSelector component.
+
+To ensure the frontend correctly uses the deployed contracts:
+
+1. Update the `ATTESTATION_SERVICE_ADDRESS` in `utils/constants.ts` with your newly deployed contract address
+2. Update the `SCHEMA_UID` in `utils/constants.ts` with the schema UID from your deployment
+
+## Transaction Verification
+
+To verify your transactions on Base mainnet:
+
+- Contract deployment: https://basescan.org/address/<deployed-contract-address>
+- Schema creation: https://base.easscan.org/schema/<schema-uid>
+- Attestations: https://base.easscan.org/attestation/<attestation-id>
+
+## Troubleshooting
+
+### Common Deployment Issues
+
+1. **Insufficient Funds**: Ensure your deployment wallet has enough Base ETH to cover the deployment costs.
+   
+2. **Gas Price Spikes**: If gas prices are unusually high, consider waiting for a period of lower network activity.
+
+3. **Contract Verification Failures**: If contract verification fails, ensure you're using the exact same compiler settings as in the hardhat.config.cjs file.
+
+### Common Frontend Integration Issues
+
+1. **Network Switching Issues**: If users experience problems switching networks, ensure they have the Base mainnet configured in their wallet.
+
+2. **Attestation Creation Failures**: Check that the wallet has been granted the attestation creator role and has sufficient funds for gas.
+
+## Security Considerations
+
+1. **Private Key Management**: Never expose your deployment private key. Use environment variables and ensure they are not committed to the repository.
+
+2. **Access Control**: Only grant the attestation creator role to trusted addresses.
+
+3. **Contract Upgrades**: The AttestationService contract uses the UUPS upgradeable pattern. Any upgrades should be thoroughly tested before deployment.
+
+## Monitoring and Maintenance
+
+After deployment, regularly monitor:
+
+1. **Contract Activity**: Check for any unexpected attestations or schema changes.
+
+2. **Gas Costs**: Monitor gas costs for attestation creation to ensure they remain within expected ranges.
+
+3. **User Feedback**: Collect feedback from users about the attestation process and network selection experience.
+
+## Conclusion
+
+Following this guide will help you successfully deploy the Mission Enrollment contracts to Base mainnet and integrate them with your frontend. Remember to test thoroughly on Base Sepolia before proceeding with mainnet deployment.

--- a/hardhat.config.cjs
+++ b/hardhat.config.cjs
@@ -19,10 +19,17 @@ const config = {
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 84532
     },
+    "base-mainnet": {
+      url: process.env.NEXT_PUBLIC_BASE_MAINNET_RPC_URL || "https://mainnet.base.org",
+      accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
+      chainId: 8453,
+      gasPrice: 1000000000 // 1 gwei
+    },
   },
   etherscan: {
     apiKey: {
-      "base-sepolia": "blockscout" // No API key needed for Blockscout
+      "base-sepolia": "blockscout", // No API key needed for Blockscout
+      "base-mainnet": "PLACEHOLDER" // Replace with actual API key if needed
     },
     customChains: [
       {
@@ -31,6 +38,14 @@ const config = {
         urls: {
           apiURL: "https://base-sepolia.blockscout.com/api",
           browserURL: "https://base-sepolia.blockscout.com"
+        }
+      },
+      {
+        network: "base-mainnet",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.basescan.org/api",
+          browserURL: "https://basescan.org"
         }
       }
     ]

--- a/hooks/useNetworkSwitch.ts
+++ b/hooks/useNetworkSwitch.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAccount, useConfig } from 'wagmi';
 import { switchNetwork } from 'wagmi/actions';
 import { getRequiredNetwork } from '../utils/constants';
+import { useUserNetworkPreference } from './useUserNetworkPreference';
 
 export const useNetworkSwitch = (action: 'verification' | 'attestation') => {
   const [isLoading, setIsLoading] = useState(false);
@@ -11,8 +12,10 @@ export const useNetworkSwitch = (action: 'verification' | 'attestation') => {
   const { chain } = useAccount();
   const config = useConfig();
   const chainId = chain?.id;
-
-  const targetNetwork = getRequiredNetwork(action);
+  
+  const { preferredNetwork } = useUserNetworkPreference();
+  
+  const targetNetwork = getRequiredNetwork(action, action === 'attestation' ? preferredNetwork : undefined);
 
   const handleNetworkSwitch = async () => {
     setIsLoading(true);

--- a/hooks/useUserNetworkPreference.ts
+++ b/hooks/useUserNetworkPreference.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+import { BASE_SEPOLIA_CHAIN_ID } from '../utils/constants';
+
+const USER_NETWORK_PREFERENCE_KEY = 'mission-enrollment-network-preference';
+
+export const useUserNetworkPreference = () => {
+  const [preferredNetwork, setPreferredNetworkState] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const storedPreference = localStorage.getItem(USER_NETWORK_PREFERENCE_KEY);
+    if (storedPreference) {
+      try {
+        setPreferredNetworkState(parseInt(storedPreference));
+      } catch (e) {
+        console.error('Failed to parse stored network preference', e);
+        setPreferredNetworkState(BASE_SEPOLIA_CHAIN_ID); // Default to Sepolia
+      }
+    } else {
+      setPreferredNetworkState(BASE_SEPOLIA_CHAIN_ID); // Default to Sepolia
+    }
+    setIsLoading(false);
+  }, []);
+
+  const setPreferredNetwork = (network: number) => {
+    setPreferredNetworkState(network);
+    localStorage.setItem(USER_NETWORK_PREFERENCE_KEY, network.toString());
+  };
+
+  return {
+    preferredNetwork: preferredNetwork || BASE_SEPOLIA_CHAIN_ID,
+    setPreferredNetwork,
+    isLoading
+  };
+};

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -2,10 +2,25 @@ import { ethers } from "hardhat";
 import { AttestationService } from "../typechain-types";
 import "dotenv/config";
 
-async function deployAndInitialize(): Promise<{ contract: AttestationService; schemaId: string }> {
-  // Base Sepolia EAS Contract addresses
-  const EAS_CONTRACT_ADDRESS = "0x4200000000000000000000000000000000000021";
-  const SCHEMA_REGISTRY_ADDRESS = "0x54f0e66D5A04702F5Df9BAe330295a11bD862c81";
+async function deployAndInitialize(networkId: string = 'base-sepolia'): Promise<{ contract: AttestationService; schemaId: string }> {
+  // Network-specific EAS Contract addresses
+  const EAS_CONTRACT_ADDRESSES: Record<string, string> = {
+    'base-sepolia': "0x4200000000000000000000000000000000000021",
+    'base-mainnet': "0x4200000000000000000000000000000000000021"
+  };
+  
+  // Network-specific Schema Registry addresses
+  const SCHEMA_REGISTRY_ADDRESSES: Record<string, string> = {
+    'base-sepolia': "0x54f0e66D5A04702F5Df9BAe330295a11bD862c81",
+    'base-mainnet': "0x720c2bA66D19A725143FBf5fDC5b4ADA2742682E" // Base mainnet schema registry
+  };
+  
+  const EAS_CONTRACT_ADDRESS = EAS_CONTRACT_ADDRESSES[networkId] || EAS_CONTRACT_ADDRESSES['base-sepolia'];
+  const SCHEMA_REGISTRY_ADDRESS = SCHEMA_REGISTRY_ADDRESSES[networkId] || SCHEMA_REGISTRY_ADDRESSES['base-sepolia'];
+  
+  console.log(`Deploying to ${networkId}...`);
+  console.log(`Using EAS Contract: ${EAS_CONTRACT_ADDRESS}`);
+  console.log(`Using Schema Registry: ${SCHEMA_REGISTRY_ADDRESS}`);
 
   console.log("Deploying AttestationService...");
   const AttestationService = await ethers.getContractFactory("AttestationService");
@@ -58,12 +73,15 @@ async function deployAndInitialize(): Promise<{ contract: AttestationService; sc
   console.log("EAS Contract:", EAS_CONTRACT_ADDRESS);
   console.log("Schema Registry:", SCHEMA_REGISTRY_ADDRESS);
 
-  return { attestationService, schemaId };
+  return { contract: attestationService, schemaId };
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
-deployAndInitialize()
+const networkArg = process.argv.find(arg => arg.startsWith('--network='));
+const network = networkArg ? networkArg.split('=')[1] : 'base-sepolia';
+
+deployAndInitialize(network)
   .then(() => process.exit(0))
   .catch((error: Error) => {
     console.error(error);

--- a/scripts/grantAttestationCreatorRole.ts
+++ b/scripts/grantAttestationCreatorRole.ts
@@ -1,0 +1,56 @@
+import { ethers } from "hardhat";
+import "dotenv/config";
+
+async function grantRole() {
+  const args = process.argv.slice(2);
+  const addressArgIndex = args.findIndex(arg => arg === '--address');
+  
+  let addressToGrant: string;
+  
+  if (addressArgIndex !== -1 && args.length > addressArgIndex + 1) {
+    addressToGrant = args[addressArgIndex + 1];
+  } else {
+    addressToGrant = process.env.ATTESTATION_CREATOR_ADDRESS || '';
+    
+    if (!addressToGrant) {
+      throw new Error("No address provided. Use --address <address> or set ATTESTATION_CREATOR_ADDRESS environment variable");
+    }
+  }
+  
+  const networkArgIndex = args.findIndex(arg => arg.startsWith('--network='));
+  const network = networkArgIndex !== -1 
+    ? args[networkArgIndex].split('=')[1] 
+    : 'base-sepolia';
+  
+  console.log(`Network: ${network}`);
+  console.log(`Granting attestation creator role to: ${addressToGrant}`);
+  
+  const [deployer] = await ethers.getSigners();
+  console.log("Using deployer account:", deployer.address);
+  
+  const contractAddress = process.env.ATTESTATION_SERVICE_ADDRESS;
+  if (!contractAddress) {
+    throw new Error("ATTESTATION_SERVICE_ADDRESS environment variable not set");
+  }
+  
+  console.log(`Using contract at address: ${contractAddress}`);
+  
+  const AttestationService = await ethers.getContractFactory("AttestationService");
+  const attestationService = AttestationService.attach(contractAddress);
+  
+  console.log(`Granting ATTESTATION_CREATOR_ROLE to ${addressToGrant}...`);
+  const tx = await attestationService.grantAttestationCreatorRole(addressToGrant);
+  await tx.wait();
+  
+  console.log("Role granted successfully!");
+  
+  const hasRole = await attestationService.isApprovedAttestationCreator(addressToGrant);
+  console.log(`Address ${addressToGrant} has ATTESTATION_CREATOR_ROLE: ${hasRole}`);
+}
+
+grantRole()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,7 +8,8 @@ export const BASE_MAINNET_CHAIN_ID = base.id;
 export const MISSION_ENROLLMENT_BASE_ETH_ADDRESS = '0xF0bC5CC2B4866dAAeCb069430c60b24520077037';
 export const EAS_CONTRACT_ADDRESS_BASE = '0x4200000000000000000000000000000000000021';
 export const EAS_CONTRACT_ADDRESS_SEPOLIA = '0x4200000000000000000000000000000000000021'; // Base Sepolia EAS address
-export const EAS_CONTRACT_ADDRESS = EAS_CONTRACT_ADDRESS_SEPOLIA; // Default to Sepolia for attestations
+export const EAS_CONTRACT_ADDRESS = (chainId: number) => 
+  chainId === BASE_MAINNET_CHAIN_ID ? EAS_CONTRACT_ADDRESS_BASE : EAS_CONTRACT_ADDRESS_SEPOLIA;
 export const ATTESTATION_SERVICE_ADDRESS = '0x60Ed99B474C0F02649C4038684A7C3FfF5EEe53D';
 
 // Schema Configuration
@@ -47,10 +48,16 @@ export const getNetworkName = (chainId: number): string => {
   return NETWORK_CONFIG[chainId]?.name || 'Unknown Network';
 };
 
-export const isCorrectNetwork = (chainId: number, action: 'verification' | 'attestation'): boolean => {
+export const isCorrectNetwork = (chainId: number, action: 'verification' | 'attestation', preferredNetwork?: number): boolean => {
+  if (action === 'attestation' && preferredNetwork) {
+    return chainId === preferredNetwork;
+  }
   return action === 'verification' ? chainId === base.id : chainId === baseSepolia.id;
 };
 
-export const getRequiredNetwork = (action: 'verification' | 'attestation') => {
+export const getRequiredNetwork = (action: 'verification' | 'attestation', preferredNetwork?: number) => {
+  if (action === 'attestation' && preferredNetwork) {
+    return preferredNetwork === BASE_MAINNET_CHAIN_ID ? base : baseSepolia;
+  }
   return action === 'verification' ? base : baseSepolia;
 };


### PR DESCRIPTION
# Network Selection and Base Mainnet Support

This PR adds the ability for users to select between Base Sepolia (low cost testnet) and Base mainnet when creating attestations. It also prepares the smart contracts for deployment to Base mainnet by either daqhris.base.eth or mission-enrollment.base.eth.

## Changes

- Added NetworkSelector component for users to choose between networks
- Created useUserNetworkPreference hook to manage user network preferences
- Updated constants.ts to support user-selected network
- Modified useNetworkSwitch hook to respect user preferences
- Updated EnrollmentAttestation component to use the selected network
- Added Base mainnet configuration to hardhat.config.cjs
- Updated deploy.ts script to support deployment to either network
- Added NetworkCostInfo component to educate users about costs
- Created detailed documentation for Base mainnet deployment and schema creation

## Documentation

Added comprehensive guidance for Base mainnet deployment in:
- docs/base-mainnet-deployment-guide.md

This includes detailed instructions for:
- Contract deployment
- Schema creation
- Cost estimates
- Integration steps

## Test Plan

- Manually tested the network selector UI
- Verified network switching functionality
- Confirmed the cost information display
- Validated deployment configuration for both networks

## Cost Considerations

When informing users about network costs, included these critical points:
- Base Sepolia operations are essentially free (only minimal gas fees)
- Base mainnet operations involve real costs:
  - Contract deployment: ~0.35 ETH (~€700)
  - Schema creation: ~0.05 ETH (~€100)
  - Per attestation cost: ~0.02 ETH (~€40)
