### PR TITLE
Add POAP verifications for Coinbase Developer Platform at ETHDenver 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The project includes comprehensive testing setup:
 **Mission Enrollment** provides a streamlined, one-page application for a select number of talented individuals to enroll in advance of the **_Zinneke Rescue Mission_**.
 
 1. User connects their Ethereum wallet using the wallet connector and verifies their identity with Basename or ENS name.
-2. The application fetches and displays relevant POAPs, specifically ETHGlobal Brussels 2024, extracting role information dynamically.
+2. The application fetches and displays relevant POAPs from approved events (ETHGlobal Brussels 2024 and ETHDenver Coinbase 2025), extracting role information dynamically.
 3. Its interface's second stage leads to verification of event attendance and role through POAPs before proceeding to attestation.
 4. User creates an attestation on the Base Sepolia network using EAS, with automatic network switching if needed.
 5. Upon successful attestation creation, a success screen is displayed with attestation details and a link to view it on EAS Explorer.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -52,6 +52,8 @@ export default function AboutPage(): ReactNode {
             <section className="mb-8">
               <h2 className="text-2xl font-semibold mb-4">Our Founding Story</h2>
               <p>Born at <a href="https://ethglobal.com/events/brussels" target="_blank" rel="noopener noreferrer"><strong>ETHGlobal Brussels</strong></a><ExternalLinkIcon /> during the summer of 2024, our collaborative rescue mission draws inspiration from the city's unique heritage. The Zinneke—Brussels' resilient mixed-breed dogs that once roamed the banks of the Senne River—symbolize the community we're building. We're using innovative technology to disseminate memories of the biennial <a href="https://www.zinneke.org/nl/album-photo/zinneke-parade-2024-2/" target="_blank" rel="noopener noreferrer"><strong>Zinneke Parade</strong></a><ExternalLinkIcon /> with its legendary After-Party, combined with the <a href="https://kfda.be/en/festivals/2024-edition/programme/nightlife-2024/" target="_blank" rel="noopener noreferrer">closing night of the annual <strong>Kunstenfestivaldesarts</strong></a><ExternalLinkIcon />, as <a href="https://github.com/daqhris/ZinnekeRescueMission?tab=readme-ov-file#rescue-strategy-onchain-postcards" target="_blank" rel="noopener noreferrer"><strong>onchain postcards</strong></a><ExternalLinkIcon />, in celebration of Brussels' cultural diversity.</p>
+              
+              <p className="mt-4">Our community has expanded to include participants from <a href="https://ethdenver.com/" target="_blank" rel="noopener noreferrer"><strong>ETHDenver</strong></a><ExternalLinkIcon /> events, particularly those who attended <a href="https://www.coinbase.com/developer" target="_blank" rel="noopener noreferrer"><strong>Coinbase Developer Platform</strong></a><ExternalLinkIcon /> workshops and gatherings in 2025. This expansion reflects our commitment to building a diverse and global community of blockchain enthusiasts and creators.</p>
             </section>
 
             <section className="mb-8">
@@ -59,7 +61,7 @@ export default function AboutPage(): ReactNode {
               <p>Your journey begins here with 3 steps:</p>
               <ul className="list-disc pl-6">
                 <li>Submit your onchain name during an identity check</li>
-                <li>Confirm your attendance at an international blockchain conference</li>
+                <li>Confirm your attendance at approved blockchain events (ETHGlobal Brussels or ETHDenver Coinbase 2025)</li>
                 <li>Receive an enrollment attestation on a public blockchain</li>
               </ul>
               <p className="mt-4">Once enrolled, you'll be certified and granted access to the upcoming <strong>Zinneke Rescue Mission</strong>.</p>

--- a/components/EnrollmentAttestation.tsx
+++ b/components/EnrollmentAttestation.tsx
@@ -66,15 +66,23 @@ export default function EnrollmentAttestation({
 
     try {
       setLoading(true);  // Add loading state
-      const role = await getPOAPRole(address);
+      const { role, eventType } = await getPOAPRole(address);
       const timestamp = Math.floor(Date.now() / 1000);
+
+      let eventName = "ETHGlobal Brussels 2024";
+      let eventTypeDisplay = "International Hackathon";
+      
+      if (eventType === 'ETHDENVER_COINBASE_2025') {
+        eventName = "ETHDenver Coinbase 2025";
+        eventTypeDisplay = "Developer Workshop & Hackathon";
+      }
 
       setPreviewData({
         userAddress: address,
         verifiedName,
         proofMethod: "Basename Protocol",
-        eventName: "ETHGlobal Brussels 2024",
-        eventType: "International Hackathon",
+        eventName,
+        eventType: eventTypeDisplay,
         assignedRole: role,
         missionName: "Zinneke Rescue Mission",
         timestamp,

--- a/components/EventAttendanceVerification.tsx
+++ b/components/EventAttendanceVerification.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { fetchPoaps } from '../utils/fetchPoapsUtil';
-import { VERIFIED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
+import { APPROVED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
 import { useNetworkSwitch } from '../hooks/useNetworkSwitch';
 
 interface POAPEvent {
@@ -68,7 +68,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
       let eventType = '';
 
       eventPoap = poaps.find(poap =>
-        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName =>
+        APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName =>
           poap.event.name.toLowerCase().includes(eventName.toLowerCase())
         )
       );
@@ -79,7 +79,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
 
       if (!eventPoap) {
         eventPoap = poaps.find(poap =>
-          VERIFIED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName =>
+          APPROVED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName =>
             poap.event.name.toLowerCase().includes(eventName.toLowerCase())
           )
         );
@@ -118,9 +118,9 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
 
         onVerified(true, eventInfo);
       } else {
-        console.log('No verified event POAP found');
+        console.log('No approved event POAP found');
         setVerificationStatus('error');
-        setError('No verified event attendance record found');
+        setError('No approved event attendance record found');
         onVerified(false);
       }
     } catch (error) {
@@ -155,7 +155,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
         {!hasAnswered ? (
           <div className="text-center">
             <p className="text-base-content/70 mb-6">
-              Hello {verifiedName}, did you attend any of our verified events in person?
+              Hello {verifiedName}, did you attend any of our approved events in person?
             </p>
             <div className="flex justify-center gap-4">
               <button
@@ -181,13 +181,13 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
             </svg>
             <div>
               <p>Thank you for your honesty!</p>
-              <p className="text-sm">The enrollment process requires in-person attendance at one of our verified events. We hope to see you at future events!</p>
+              <p className="text-sm">The enrollment process requires in-person attendance at one of our approved events. We hope to see you at future events!</p>
             </div>
           </div>
         ) : (
           <>
             <p className="text-base-content/70 mb-4">
-              Hello {verifiedName}, we are checking your attendance at our verified events.
+              Hello {verifiedName}, we are checking your attendance at our approved events.
             </p>
 
             {isVerifying && (
@@ -201,7 +201,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                 </p>
                 <div className="flex flex-col items-center space-y-2 text-sm text-base-content/50">
                   <p className="animate-bounce">🔍 Searching POAPs on Gnosis Chain</p>
-                  <p className="animate-pulse">🎪 Looking for verified event badges</p>
+                  <p className="animate-pulse">🎪 Looking for approved event badges</p>
                   <p>🎯 Matching your wallet address</p>
                 </div>
               </div>
@@ -224,7 +224,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                 <div className="space-y-4">
                   <div>
                     <p className="font-bold text-lg">🎉 Event attendance verified!</p>
-                    <p className="text-sm opacity-75">Your POAP confirms your participation at a verified blockchain event</p>
+                    <p className="text-sm opacity-75">Your POAP confirms your participation at an approved blockchain event</p>
                   </div>
                   <div className="flex items-center bg-base-200 rounded-lg p-4">
                     <Image
@@ -239,7 +239,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                       <p className="text-base font-semibold">
                         {poapDetails?.event?.name?.includes('ETHGlobal Brussels') ? 'ETHGlobal Brussels 2024' : 
                          poapDetails?.event?.name?.includes('Coinbase Developer Platform') ? 'ETHDenver Coinbase 2025' : 
-                         'Verified Event'}
+                         'Approved Event'}
                       </p>
                       <div className="flex flex-col text-sm opacity-75">
                         <p>🎭 Role: {poapDetails?.event?.name?.includes('ETHGlobal Brussels') ? 

--- a/components/EventAttendanceVerification.tsx
+++ b/components/EventAttendanceVerification.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { fetchPoaps } from '../utils/fetchPoapsUtil';
-import { ETH_GLOBAL_BRUSSELS_EVENT_NAMES, EVENT_VENUE } from '../utils/eventConstants';
+import { VERIFIED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
 import { useNetworkSwitch } from '../hooks/useNetworkSwitch';
 
 interface POAPEvent {
@@ -21,6 +21,7 @@ interface EventInfo {
   venue: string;
   verifiedName: string;
   tokenId: string;
+  eventType: string; // Added to identify which event the user attended
 }
 
 interface EventAttendanceVerificationProps {
@@ -63,38 +64,63 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
       const poaps = await fetchPoaps(address);
       console.log('Fetched POAPs:', poaps);
 
-      const ethGlobalBrusselsPoap = poaps.find(poap =>
-        ETH_GLOBAL_BRUSSELS_EVENT_NAMES.some(eventName =>
+      let eventPoap = null;
+      let eventType = '';
+
+      eventPoap = poaps.find(poap =>
+        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName =>
           poap.event.name.toLowerCase().includes(eventName.toLowerCase())
         )
       );
+      if (eventPoap) {
+        eventType = 'ETH_GLOBAL_BRUSSELS';
+        console.log('Found ETHGlobal Brussels POAP:', eventPoap);
+      }
+
+      if (!eventPoap) {
+        eventPoap = poaps.find(poap =>
+          VERIFIED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName =>
+            poap.event.name.toLowerCase().includes(eventName.toLowerCase())
+          )
+        );
+        if (eventPoap) {
+          eventType = 'ETHDENVER_COINBASE_2025';
+          console.log('Found ETHDenver Coinbase 2025 POAP:', eventPoap);
+        }
+      }
 
       // Add a minimum delay for the drumroll effect (15 seconds)
       await new Promise(resolve => setTimeout(resolve, 15000));
-      if (ethGlobalBrusselsPoap) {
-        console.log('Found ETHGlobal Brussels POAP:', ethGlobalBrusselsPoap);
-        setPoapDetails(ethGlobalBrusselsPoap);
+      
+      if (eventPoap) {
+        setPoapDetails(eventPoap);
         setVerificationStatus('success');
 
-        // Extract role from POAP name (e.g., "ETHGlobal Brussels Hacker" -> "Hacker")
-        const role = ethGlobalBrusselsPoap.event.name
-          .replace('ETHGlobal Brussels ', '')
-          .trim();
+        // Extract role from POAP name based on event type
+        let role = '';
+        if (eventType === 'ETH_GLOBAL_BRUSSELS') {
+          role = eventPoap.event.name
+            .replace('ETHGlobal Brussels 2024 ', '')
+            .trim();
+        } else if (eventType === 'ETHDENVER_COINBASE_2025') {
+          role = 'Attendee';
+        }
 
         // Combine verified name and POAP info for attestation
         const eventInfo: EventInfo = {
           role,
-          date: ethGlobalBrusselsPoap.event.end_date || ethGlobalBrusselsPoap.event.start_date,
-          venue: EVENT_VENUE,
+          date: eventPoap.event.end_date || eventPoap.event.start_date,
+          venue: EVENT_VENUES[eventType as keyof typeof EVENT_VENUES],
           verifiedName: verifiedName,
-          tokenId: ethGlobalBrusselsPoap.tokenId
+          tokenId: eventPoap.tokenId,
+          eventType: eventType
         };
 
         onVerified(true, eventInfo);
       } else {
-        console.log('No ETHGlobal Brussels POAP found');
+        console.log('No verified event POAP found');
         setVerificationStatus('error');
-        setError('No ETHGlobal Brussels attendance record found');
+        setError('No verified event attendance record found');
         onVerified(false);
       }
     } catch (error) {
@@ -129,7 +155,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
         {!hasAnswered ? (
           <div className="text-center">
             <p className="text-base-content/70 mb-6">
-              Hello {verifiedName}, did you attend ETHGlobal Brussels in person?
+              Hello {verifiedName}, did you attend any of our verified events in person?
             </p>
             <div className="flex justify-center gap-4">
               <button
@@ -155,13 +181,13 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
             </svg>
             <div>
               <p>Thank you for your honesty!</p>
-              <p className="text-sm">The enrollment process requires in-person attendance at ETHGlobal Brussels. We hope to see you at future events!</p>
+              <p className="text-sm">The enrollment process requires in-person attendance at one of our verified events. We hope to see you at future events!</p>
             </div>
           </div>
         ) : (
           <>
             <p className="text-base-content/70 mb-4">
-              Hello {verifiedName}, we are checking your attendance at ETHGlobal Brussels.
+              Hello {verifiedName}, we are checking your attendance at our verified events.
             </p>
 
             {isVerifying && (
@@ -175,7 +201,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                 </p>
                 <div className="flex flex-col items-center space-y-2 text-sm text-base-content/50">
                   <p className="animate-bounce">🔍 Searching POAPs on Gnosis Chain</p>
-                  <p className="animate-pulse">🎪 Looking for ETHGlobal Brussels badges</p>
+                  <p className="animate-pulse">🎪 Looking for verified event badges</p>
                   <p>🎯 Matching your wallet address</p>
                 </div>
               </div>
@@ -198,7 +224,7 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                 <div className="space-y-4">
                   <div>
                     <p className="font-bold text-lg">🎉 Event attendance verified!</p>
-                    <p className="text-sm opacity-75">Your POAP confirms your participation at a hackathon in Brussels hosted by ETHGlobal</p>
+                    <p className="text-sm opacity-75">Your POAP confirms your participation at a verified blockchain event</p>
                   </div>
                   <div className="flex items-center bg-base-200 rounded-lg p-4">
                     <Image
@@ -210,11 +236,18 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                       onError={handleImageError}
                     />
                     <div className="space-y-2">
-                      <p className="text-base font-semibold">ETHGlobal Brussels 2024</p>
+                      <p className="text-base font-semibold">
+                        {poapDetails?.event?.name?.includes('ETHGlobal Brussels') ? 'ETHGlobal Brussels 2024' : 
+                         poapDetails?.event?.name?.includes('Coinbase Developer Platform') ? 'ETHDenver Coinbase 2025' : 
+                         'Verified Event'}
+                      </p>
                       <div className="flex flex-col text-sm opacity-75">
-                        <p>🎭 Role: {poapDetails?.event?.name?.replace('ETHGlobal Brussels 2024', '') || 'Attendee'}</p>
+                        <p>🎭 Role: {poapDetails?.event?.name?.includes('ETHGlobal Brussels') ? 
+                          poapDetails?.event?.name?.replace('ETHGlobal Brussels 2024', '') : 'Attendee'}</p>
                         <p>📅 Date: {new Date(poapDetails?.event?.end_date || poapDetails?.event?.start_date || Date.now()).toLocaleDateString()}</p>
-                        <p>📍 Venue: {EVENT_VENUE}</p>
+                        <p>📍 Venue: {poapDetails?.event?.name?.includes('ETHGlobal Brussels') ? 
+                          EVENT_VENUES.ETH_GLOBAL_BRUSSELS : 
+                          EVENT_VENUES.ETHDENVER_COINBASE_2025}</p>
                         <p>🎫 Token ID: {poapDetails?.tokenId || 'N/A'}</p>
                       </div>
                     </div>
@@ -228,14 +261,25 @@ const EventAttendanceVerification: React.FC<EventAttendanceVerificationProps> = 
                 className={`btn w-full ${networkSwitched || attestationId ? 'btn-disabled opacity-50' : 'btn-primary'}`}
                 onClick={async () => {
                   const success = await handleNetworkSwitch();
-                  if (success) {
-                    onVerified(true, poapDetails ? {
-                      role: poapDetails.event.name.replace('ETHGlobal Brussels ', '').trim(),
+                  if (success && poapDetails) {
+                    const eventType = poapDetails.event.name.includes('ETHGlobal Brussels') 
+                      ? 'ETH_GLOBAL_BRUSSELS' 
+                      : 'ETHDENVER_COINBASE_2025';
+                    
+                    // Extract role based on event type
+                    let role = 'Attendee';
+                    if (eventType === 'ETH_GLOBAL_BRUSSELS') {
+                      role = poapDetails.event.name.replace('ETHGlobal Brussels 2024 ', '').trim();
+                    }
+                    
+                    onVerified(true, {
+                      role,
                       date: poapDetails.event.end_date || poapDetails.event.start_date,
-                      venue: EVENT_VENUE,
+                      venue: EVENT_VENUES[eventType as keyof typeof EVENT_VENUES],
                       verifiedName: verifiedName,
-                      tokenId: poapDetails.tokenId
-                    } : undefined);
+                      tokenId: poapDetails.tokenId,
+                      eventType
+                    });
                   }
                 }}
                 disabled={networkSwitched || verificationStatus !== 'success' || !!attestationId}

--- a/test/poapVerification.test.ts
+++ b/test/poapVerification.test.ts
@@ -1,5 +1,5 @@
 import { fetchPoaps } from '../utils/fetchPoapsUtil';
-import { VERIFIED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
+import { APPROVED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
 import { mockPoapsResponse, mockValidWalletAddresses } from './mocks/poapData';
 
 // Mock fetchPoaps function
@@ -19,7 +19,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoaps = poaps.filter(poap =>
-        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
+        APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       expect(ethGlobalBrusselsPoaps.length).toBeGreaterThan(0);
@@ -31,7 +31,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoap = poaps.find(poap =>
-        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
+        APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       if (!ethGlobalBrusselsPoap) throw new Error('No ETHGlobal Brussels POAP found');
@@ -47,7 +47,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoap = poaps.find(poap =>
-        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
+        APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       if (!ethGlobalBrusselsPoap) throw new Error('No ETHGlobal Brussels POAP found');

--- a/test/poapVerification.test.ts
+++ b/test/poapVerification.test.ts
@@ -1,5 +1,5 @@
 import { fetchPoaps } from '../utils/fetchPoapsUtil';
-import { ETH_GLOBAL_BRUSSELS_EVENT_NAMES, EVENT_VENUE } from '../utils/eventConstants';
+import { VERIFIED_EVENT_NAMES, EVENT_VENUES } from '../utils/eventConstants';
 import { mockPoapsResponse, mockValidWalletAddresses } from './mocks/poapData';
 
 // Mock fetchPoaps function
@@ -19,7 +19,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoaps = poaps.filter(poap =>
-        ETH_GLOBAL_BRUSSELS_EVENT_NAMES.includes(poap.event.name as typeof ETH_GLOBAL_BRUSSELS_EVENT_NAMES[number])
+        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       expect(ethGlobalBrusselsPoaps.length).toBeGreaterThan(0);
@@ -31,7 +31,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoap = poaps.find(poap =>
-        ETH_GLOBAL_BRUSSELS_EVENT_NAMES.includes(poap.event.name as typeof ETH_GLOBAL_BRUSSELS_EVENT_NAMES[number])
+        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       if (!ethGlobalBrusselsPoap) throw new Error('No ETHGlobal Brussels POAP found');
@@ -47,7 +47,7 @@ describe('POAP Verification', () => {
 
       const poaps = await fetchPoaps(address);
       const ethGlobalBrusselsPoap = poaps.find(poap =>
-        ETH_GLOBAL_BRUSSELS_EVENT_NAMES.includes(poap.event.name as typeof ETH_GLOBAL_BRUSSELS_EVENT_NAMES[number])
+        VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.includes(poap.event.name as typeof VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS[number])
       );
 
       if (!ethGlobalBrusselsPoap) throw new Error('No ETHGlobal Brussels POAP found');
@@ -55,7 +55,7 @@ describe('POAP Verification', () => {
       const eventInfo = {
         role: ethGlobalBrusselsPoap.event.name.replace('ETHGlobal Brussels ', ''),
         date: ethGlobalBrusselsPoap.event.start_date,
-        venue: EVENT_VENUE,
+        venue: EVENT_VENUES.ETH_GLOBAL_BRUSSELS,
         verifiedName,
         tokenId: ethGlobalBrusselsPoap.tokenId
       };
@@ -63,7 +63,7 @@ describe('POAP Verification', () => {
       expect(eventInfo).toMatchObject({
         role: expect.any(String),
         date: expect.any(String),
-        venue: EVENT_VENUE,
+        venue: EVENT_VENUES.ETH_GLOBAL_BRUSSELS,
         verifiedName: expect.any(String),
         tokenId: expect.any(String)
       });

--- a/utils/eventConstants.ts
+++ b/utils/eventConstants.ts
@@ -1,10 +1,23 @@
-export const ETH_GLOBAL_BRUSSELS_EVENT_NAMES = [
-  'ETHGlobal Brussels 2024 Hacker',
-  'ETHGlobal Brussels 2024 Sponsor',
-  'ETHGlobal Brussels 2024 Speaker',
-  'ETHGlobal Brussels 2024 Mentor',
-  'ETHGlobal Brussels 2024 Staff',
-  'ETHGlobal Brussels 2024 Volunteer'
-] as const;
+export const VERIFIED_EVENT_NAMES = {
+  ETH_GLOBAL_BRUSSELS: [
+    'ETHGlobal Brussels 2024 Hacker',
+    'ETHGlobal Brussels 2024 Sponsor',
+    'ETHGlobal Brussels 2024 Speaker',
+    'ETHGlobal Brussels 2024 Mentor',
+    'ETHGlobal Brussels 2024 Staff',
+    'ETHGlobal Brussels 2024 Volunteer'
+  ] as const,
+  ETHDENVER_COINBASE_2025: [
+    'Coinbase Developer Platform at ETHDenver 2025',
+    'Coinbase Developer Platform at #BUIDLWeek - EthDenver 2025',
+    'Coinbase Developer Platform - EthDenver Happy Hour 2025'
+  ] as const
+};
 
-export const EVENT_VENUE = 'The EGG Brussels, Rue Bara 175, 1070 Brussels, Belgium';
+export const EVENT_VENUES = {
+  ETH_GLOBAL_BRUSSELS: 'The EGG Brussels, Rue Bara 175, 1070 Brussels, Belgium',
+  ETHDENVER_COINBASE_2025: 'National Western Complex, Denver, Colorado, USA'
+};
+
+export const ETH_GLOBAL_BRUSSELS_EVENT_NAMES = VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS;
+export const EVENT_VENUE = EVENT_VENUES.ETH_GLOBAL_BRUSSELS;

--- a/utils/eventConstants.ts
+++ b/utils/eventConstants.ts
@@ -1,4 +1,4 @@
-export const VERIFIED_EVENT_NAMES = {
+export const APPROVED_EVENT_NAMES = {
   ETH_GLOBAL_BRUSSELS: [
     'ETHGlobal Brussels 2024 Hacker',
     'ETHGlobal Brussels 2024 Sponsor',
@@ -19,5 +19,5 @@ export const EVENT_VENUES = {
   ETHDENVER_COINBASE_2025: 'National Western Complex, Denver, Colorado, USA'
 };
 
-export const ETH_GLOBAL_BRUSSELS_EVENT_NAMES = VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS;
+export const ETH_GLOBAL_BRUSSELS_EVENT_NAMES = APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS;
 export const EVENT_VENUE = EVENT_VENUES.ETH_GLOBAL_BRUSSELS;

--- a/utils/poap.ts
+++ b/utils/poap.ts
@@ -1,5 +1,5 @@
 import { POAP_API_URL } from './constants';
-import { VERIFIED_EVENT_NAMES } from './eventConstants';
+import { APPROVED_EVENT_NAMES } from './eventConstants';
 
 interface POAPEvent {
   event: {
@@ -29,7 +29,7 @@ export async function getPOAPRole(address: string): Promise<POAPRoleResult> {
     const data = await response.json();
     
     const ethGlobalEvent = data.find((poap: POAPEvent) =>
-      VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName => 
+      APPROVED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName => 
         poap.event.name.toLowerCase().includes(eventName.toLowerCase())
       )
     );
@@ -56,7 +56,7 @@ export async function getPOAPRole(address: string): Promise<POAPRoleResult> {
     }
 
     const ethDenverEvent = data.find((poap: POAPEvent) =>
-      VERIFIED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName => 
+      APPROVED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName => 
         poap.event.name.toLowerCase().includes(eventName.toLowerCase())
       )
     );

--- a/utils/poap.ts
+++ b/utils/poap.ts
@@ -1,4 +1,5 @@
 import { POAP_API_URL } from './constants';
+import { VERIFIED_EVENT_NAMES } from './eventConstants';
 
 interface POAPEvent {
   event: {
@@ -7,7 +8,12 @@ interface POAPEvent {
   }
 }
 
-export async function getPOAPRole(address: string): Promise<string> {
+interface POAPRoleResult {
+  role: string;
+  eventType: string;
+}
+
+export async function getPOAPRole(address: string): Promise<POAPRoleResult> {
   try {
     const response = await fetch(POAP_API_URL + '/actions/scan/' + address, {
       headers: {
@@ -17,34 +23,54 @@ export async function getPOAPRole(address: string): Promise<string> {
 
     if (!response.ok) {
       console.error('Failed to fetch POAP data:', await response.text());
-      return 'Participant';
+      return { role: 'Participant', eventType: 'ETH_GLOBAL_BRUSSELS' };
     }
 
     const data = await response.json();
+    
     const ethGlobalEvent = data.find((poap: POAPEvent) =>
-      poap.event.name.toLowerCase().includes('ethglobal brussels')
+      VERIFIED_EVENT_NAMES.ETH_GLOBAL_BRUSSELS.some(eventName => 
+        poap.event.name.toLowerCase().includes(eventName.toLowerCase())
+      )
     );
 
-    if (!ethGlobalEvent) {
-      return 'Participant';
+    if (ethGlobalEvent) {
+      const roleMapping: Record<string, string> = {
+        'hacker': 'Hacker',
+        'mentor': 'Mentor',
+        'judge': 'Judge',
+        'sponsor': 'Sponsor',
+        'organizer': 'Organizer',
+        'volunteer': 'Volunteer'
+      };
+
+      const role = Object.entries(roleMapping).find(([key]) =>
+        ethGlobalEvent.event.description.toLowerCase().includes(key) || 
+        ethGlobalEvent.event.name.toLowerCase().includes(key)
+      );
+
+      return { 
+        role: role ? role[1] : 'Participant', 
+        eventType: 'ETH_GLOBAL_BRUSSELS' 
+      };
     }
 
-    const roleMapping: Record<string, string> = {
-      'hacker': 'Hacker',
-      'mentor': 'Mentor',
-      'judge': 'Judge',
-      'sponsor': 'Sponsor',
-      'organizer': 'Organizer',
-      'volunteer': 'Volunteer'
-    };
-
-    const role = Object.entries(roleMapping).find(([key]) =>
-      ethGlobalEvent.event.description.toLowerCase().includes(key)
+    const ethDenverEvent = data.find((poap: POAPEvent) =>
+      VERIFIED_EVENT_NAMES.ETHDENVER_COINBASE_2025.some(eventName => 
+        poap.event.name.toLowerCase().includes(eventName.toLowerCase())
+      )
     );
 
-    return role ? role[1] : 'Participant';
+    if (ethDenverEvent) {
+      return { 
+        role: 'Attendee', 
+        eventType: 'ETHDENVER_COINBASE_2025' 
+      };
+    }
+
+    return { role: 'Participant', eventType: 'ETH_GLOBAL_BRUSSELS' };
   } catch (error) {
     console.error('Error fetching POAP role:', error);
-    return 'Participant';
+    return { role: 'Participant', eventType: 'ETH_GLOBAL_BRUSSELS' };
   }
 }


### PR DESCRIPTION
# Add POAP verifications for ETHDenver Coinbase 2025 and rename "verified" to "approved"

This PR implements additional POAP verifications for Coinbase Developer Platform events at ETHDenver 2025 and updates terminology throughout the codebase. Changes include:

1. Renamed `ETH_GLOBAL_BRUSSELS_EVENT_NAMES` to `APPROVED_EVENT_NAMES` (previously named `VERIFIED_EVENT_NAMES`)
2. Added constants for Coinbase Developer Platform POAPs from ETHDenver 2025:
   - "Coinbase Developer Platform at ETHDenver 2025"
   - "Coinbase Developer Platform at #BUIDLWeek - EthDenver 2025"
   - "Coinbase Developer Platform - EthDenver Happy Hour 2025"
3. Updated the verification logic to handle multiple events
4. Modified UI elements to be event-agnostic, replacing all instances of "verified" with "approved"
5. Updated the About page to mention ETHDenver Coinbase 2025 events
6. Updated the README to reflect the new POAP verification feature
