### PR TITLE
EAS Schema Draft

### DIFF
--- a/docs/eas-schema-draft.md
+++ b/docs/eas-schema-draft.md
@@ -1,0 +1,66 @@
+# EAS Schema Draft for Mission Enrollment
+
+This document outlines a proposed update to the Ethereum Attestation Service (EAS) schema used for Mission Enrollment attestations, aligning field names with UI terminology and ensuring proper data structure.
+
+## Current Schema Structure
+
+The current schema (Schema 910) uses the following encoding:
+```typescript
+"address userAddress,string verifiedName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address attester,string proofProtocol,string verificationSource,string verificationTimestamp,string verificationSignature,string verificationHash"
+```
+
+## Proposed Schema Structure
+
+The proposed schema includes field name updates to align with UI terminology while maintaining backward compatibility:
+```typescript
+"address userAddress,string onchainName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address publicAttester,string proofProtocol,string schemaDeployer,string verificationTime,string verificationSignature,string verificationHash"
+```
+
+## Field Descriptions
+
+| Field Name | Type | Description | UI Display Name |
+|------------|------|-------------|----------------|
+| userAddress | address | Wallet address of the attestation recipient | User Address |
+| onchainName | string | User's Base name (e.g., name.base.eth) | Onchain Name |
+| proofMethod | string | Method used to verify identity (e.g., "Basename Protocol") | Proof Method |
+| eventName | string | Name of the event attended (e.g., "ETHGlobal Brussels 2024") | Event Name |
+| eventType | string | Type of event (e.g., "International Hackathon") | Event Type |
+| assignedRole | string | Role assigned based on POAP data (e.g., Hacker, Mentor, Speaker) | Assigned Role |
+| missionName | string | Name of the collaborative mission (e.g., "Zinneke Rescue Mission") | Mission |
+| timestamp | uint256 | Timestamp of attestation creation in milliseconds | (Not displayed) |
+| publicAttester | address | Address of the attestation creator (mission-enrollment.base.eth) | Public Attester |
+| proofProtocol | string | Protocol used for verification (e.g., "EAS Schema #1157") | Proof Protocol |
+| schemaDeployer | string | Source of the schema (e.g., "mission-enrollment.base.eth") | Schema Deployer |
+| verificationTime | string | ISO timestamp of verification | Verification Time |
+| verificationSignature | string | EIP-712 signature for verification | Signature |
+| verificationHash | string | Hash of verification data | Hash |
+
+## EIP-712 Structure
+
+The EIP-712 structure for type-safe signing should be updated to match the schema:
+
+```typescript
+const EIP712_TYPES = {
+  Verification: [
+    { name: 'userAddress', type: 'address' },
+    { name: 'eventName', type: 'string' },
+    { name: 'assignedRole', type: 'string' },
+    { name: 'onchainName', type: 'string' },
+    { name: 'timestamp', type: 'uint256' }
+  ]
+};
+```
+
+## Implementation Notes
+
+1. **Role Information**: Roles should be dynamically retrieved from the user's POAP data rather than hardcoded. The possible roles include:
+   - ETH_GLOBAL_BRUSSELS: Hacker, Mentor, Judge, Sponsor, Speaker, Volunteer, Staff
+   - ETHDENVER_COINBASE_2025: Speaker, Sponsor, Mentor, Judge, Developer, Hacker, Social Participant, BUIDLer
+
+2. **Base Names**: Base names should be formatted consistently, removing duplicate suffixes like ".base.eth.base.eth"
+
+3. **Timestamp Handling**: Timestamps should be stored as milliseconds since epoch (using `Date.now()`) and formatted for display without "T" and "Z" characters
+
+4. **Attester Address**: The attester's wallet address in attestation data should match the wallet that deployed the schema on Base Sepolia
+
+5. **Network Specifics**: The schema is intended for use on Base Sepolia testnet with proper display on EAS Explorer

--- a/docs/eas-schema-draft.md
+++ b/docs/eas-schema-draft.md
@@ -4,7 +4,7 @@ This document outlines a proposed update to the Ethereum Attestation Service (EA
 
 ## Current Schema Structure
 
-The current schema (Schema 910) uses the following encoding:
+The current schema (Schema 1157) uses the following encoding:
 ```typescript
 "address userAddress,string verifiedName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address attester,string proofProtocol,string verificationSource,string verificationTimestamp,string verificationSignature,string verificationHash"
 ```
@@ -63,4 +63,4 @@ const EIP712_TYPES = {
 
 4. **Attester Address**: The attester's wallet address in attestation data should match the wallet that deployed the schema on Base Sepolia
 
-5. **Network Specifics**: The schema is intended for use on Base Sepolia testnet with proper display on EAS Explorer
+5. **Network Specifics**: The schema is intended for use on Base Sepolia testnet with proper display on EAS Explorer at https://base-sepolia.easscan.org/schema/view/0x24e3eb564e8e879fbcae9b5d16ebf0d7d880cf5ec58fef0d4f74c9d6f594475e

--- a/docs/eas-schema-implementation.md
+++ b/docs/eas-schema-implementation.md
@@ -1,0 +1,95 @@
+# EAS Schema Implementation Guide
+
+This document provides code examples for implementing the updated EAS schema in the Mission Enrollment application.
+
+## Schema Constants Update
+
+```typescript
+// In utils/constants.ts
+export const SCHEMA_UID_UPDATED = '0x...'; // New schema UID after deployment
+export const SCHEMA_ENCODING_UPDATED = "address userAddress,string onchainName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address publicAttester,string proofProtocol,string schemaDeployer,string verificationTime,string verificationSignature,string verificationHash";
+```
+
+## Schema Data Interface Update
+
+```typescript
+// In types/attestation.ts
+export interface SchemaData {
+  userAddress: string;      // address - wallet address
+  onchainName: string;      // string - verified name from Basename
+  proofMethod: string;      // string - "Basename Protocol"
+  eventName: string;        // string - "ETHGlobal Brussels 2024"
+  eventType: string;        // string - "International Hackathon"
+  assignedRole: string;     // string - dynamic role from POAP
+  missionName: string;      // string - "Zinneke Rescue Mission"
+  timestamp: number;        // uint256 - block timestamp
+  publicAttester: string;   // address - MISSION_ENROLLMENT_BASE_ETH_ADDRESS
+  proofProtocol: string;    // string - "EAS Protocol"
+  schemaDeployer: string;   // string - "mission-enrollment.base.eth"
+  verificationTime: string; // string - ISO timestamp
+  verificationSignature: string; // string - app-generated signature
+  verificationHash: string; // string - deterministic hash
+}
+```
+
+## EIP-712 Types Update
+
+```typescript
+// In utils/attestationVerification.ts
+const EIP712_TYPES = {
+  Verification: [
+    { name: 'userAddress', type: 'address' },
+    { name: 'eventName', type: 'string' },
+    { name: 'assignedRole', type: 'string' },
+    { name: 'onchainName', type: 'string' },
+    { name: 'timestamp', type: 'uint256' }
+  ]
+};
+```
+
+## Schema Encoder Update
+
+```typescript
+// In components/EnrollmentAttestation.tsx
+const schemaEncoder = new SchemaEncoder(SCHEMA_ENCODING_UPDATED);
+const encodedData = schemaEncoder.encodeData([
+  { name: "userAddress", value: previewData.userAddress, type: "address" },
+  { name: "onchainName", value: previewData.approvedName, type: "string" },
+  { name: "proofMethod", value: previewData.proofMethod, type: "string" },
+  { name: "eventName", value: previewData.eventName, type: "string" },
+  { name: "eventType", value: previewData.eventType, type: "string" },
+  { name: "assignedRole", value: previewData.assignedRole, type: "string" },
+  { name: "missionName", value: previewData.missionName, type: "string" },
+  { name: "timestamp", value: previewData.timestamp, type: "uint256" },
+  { name: "publicAttester", value: previewData.attester, type: "address" },
+  { name: "proofProtocol", value: previewData.proofProtocol, type: "string" },
+  { name: "schemaDeployer", value: previewData.verificationSource, type: "string" },
+  { name: "verificationTime", value: previewData.verificationTimestamp, type: "string" },
+  { name: "verificationSignature", value: signature, type: "string" },
+  { name: "verificationHash", value: previewData.verificationHash, type: "string" }
+]);
+```
+
+## Field Labels Update
+
+```typescript
+// In utils/formatting.ts
+export function getFieldLabel(name: string): string {
+  const labels: Record<string, string> = {
+    userAddress: 'User Address',
+    onchainName: 'Onchain Name',
+    proofMethod: 'Proof Method',
+    eventName: 'Event',
+    eventType: 'Type',
+    assignedRole: 'Role',
+    missionName: 'Mission',
+    publicAttester: 'Public Attester',
+    proofProtocol: 'Proof Protocol',
+    schemaDeployer: 'Schema Deployer',
+    verificationTime: 'Verification Time',
+    verificationSignature: 'Signature',
+    verificationHash: 'Hash'
+  };
+  return labels[name] || name;
+}
+```

--- a/docs/eas-schema-implementation.md
+++ b/docs/eas-schema-implementation.md
@@ -6,6 +6,7 @@ This document provides code examples for implementing the updated EAS schema in 
 
 ```typescript
 // In utils/constants.ts
+export const SCHEMA_UID_CURRENT = '0x24e3eb564e8e879fbcae9b5d16ebf0d7d880cf5ec58fef0d4f74c9d6f594475e'; // Schema 1157 UID
 export const SCHEMA_UID_UPDATED = '0x...'; // New schema UID after deployment
 export const SCHEMA_ENCODING_UPDATED = "address userAddress,string onchainName,string proofMethod,string eventName,string eventType,string assignedRole,string missionName,uint256 timestamp,address publicAttester,string proofProtocol,string schemaDeployer,string verificationTime,string verificationSignature,string verificationHash";
 ```


### PR DESCRIPTION
# EAS Schema Draft Documentation

1. Created two documentation files:
   - `docs/eas-schema-draft.md`: Comprehensive schema proposal with field descriptions
   - `docs/eas-schema-implementation.md`: Implementation guide with code examples

2. Updated all references to use Schema 1157 instead of 910

