### PR TITLE
Fix success message to adapt based on event type

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,6 +50,7 @@ export default function Home() {
     venue: string;
     approvedName: string;
     tokenId: string;
+    eventType: string;
   } | null>(null);
   
 
@@ -264,6 +265,7 @@ export default function Home() {
                         attestationId={attestationId}
                         verifiedName={eventInfo.approvedName}
                         role={eventInfo.role}
+                        eventType={eventInfo.eventType}
                       />
                     </div>
                   )}

--- a/components/SuccessAttestation.tsx
+++ b/components/SuccessAttestation.tsx
@@ -4,9 +4,19 @@ interface SuccessAttestationProps {
   attestationId: string;
   verifiedName: string;
   role: string;
+  eventType?: string; // Added to handle different event types
 }
 
-export function SuccessAttestation({ attestationId, verifiedName, role }: SuccessAttestationProps) {
+export function SuccessAttestation({ attestationId, verifiedName, role, eventType = 'ETH_GLOBAL_BRUSSELS' }: SuccessAttestationProps) {
+  let locationMessage = "in Brussels";
+  let eventDescription = "hackathon skills demonstrated";
+  let missionName = "Zinneke Rescue Mission";
+
+  if (eventType === 'ETHDENVER_COINBASE_2025') {
+    locationMessage = "in Denver";
+    eventDescription = "developer workshop skills demonstrated";
+  }
+
   return (
     <div className="mt-8">
       <h2 className="text-2xl font-bold mb-4">Registration Complete</h2>
@@ -20,8 +30,8 @@ export function SuccessAttestation({ attestationId, verifiedName, role }: Succes
           </div>
 
           <div className="mt-4">
-            <p className="text-lg mb-2">Registered for the upcoming <span className="font-semibold">Zinneke Rescue Mission</span> as: <span className="font-semibold">{verifiedName}</span></p>
-            <p className="text-lg mb-4">In honor of your hackathon skills demonstrated in Brussels as: <span className="font-semibold">{role}</span></p>
+            <p className="text-lg mb-2">Registered for the upcoming <span className="font-semibold">{missionName}</span> as: <span className="font-semibold">{verifiedName}</span></p>
+            <p className="text-lg mb-4">In honor of your {eventDescription} {locationMessage} as: <span className="font-semibold">{role}</span></p>
             <p className="text-sm text-base-content/70 mb-2">Attestation ID: {attestationId}</p>
             <a
               href={`https://base-sepolia.easscan.org/attestation/view/${attestationId}`}


### PR DESCRIPTION
# Dynamic Success Messages Based on Event Type

This PR modifies the success message displayed after attestation to adapt based on the event type the user attended.

## Changes
- Added `eventType` prop to `SuccessAttestation` component
- Implemented conditional logic to display different messages based on event type:
  - ETHGlobal Brussels: "hackathon skills demonstrated in Brussels"
  - ETHDenver Coinbase: "developer workshop skills demonstrated in Denver"
- Updated `app/page.tsx` to pass the event type information to the component

These changes ensure that users who attended ETHDenver workshops will see appropriate messaging that reflects their participation, rather than the previously hardcoded Brussels hackathon text.
